### PR TITLE
release: v0.1.0-beta.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            # `dev` on a dev push AND on a release tag: a tag is cut FROM dev, so leaving :dev
+            # pointing at the previous build meant the newest code was on :latest but not on the
+            # tag people testing pre-release are actually pulling.
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}}
             # During 0.x beta, :latest intentionally follows EVERY release tag
             # (including -beta.N) so testers pulling :latest get the newest beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project are documented here. This project follows
 [Conventional Commits](https://www.conventionalcommits.org/) and
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.0-beta.3] - 2026-07-22
+
+Picks that actually resemble what you watched.
+
+### Ranking
+
+A beta user's row seeded by **The Pitt** — a medical drama — came back as The Sandman, Servant,
+Torchwood and King & Conqueror. TMDB was not at fault: its recommendations for that show are ER,
+Chicago Med, Grey's Anatomy, Code Black, The Good Doctor. Shortlist was reading the right list and
+picking from the wrong end of it.
+
+- **TMDB's ordering is no longer thrown away.** Suggestions were pooled into one bag, so "#1 closest
+  match" and "#19, loosely related" arrived indistinguishable — and `/similar` (keyword matching)
+  was weighted the same as `/recommendations` (what people actually watch together).
+- **Ranking now asks whether a title is similar, not just well-rated.** With position discarded, the
+  only thing separating candidates was TMDB's average vote — which on real data put *Traitors*, a
+  reality competition show, at the top of a medical drama's row.
+- **Genre coherence.** Position alone wasn't enough: TMDB tags The Pitt simply "Drama", as it does
+  nearly everything it suggests. But Torchwood and The Sandman are *also* "Sci-Fi & Fantasy", and
+  that foreign genre is the whole difference.
+
+Sources with no ranking of their own — discover, Trakt, the AI sources — are unaffected. They are
+deliberate picks, not the tail of a list.
+
+### Rows can be short now
+
+Filling a half-empty row from the tail is how a weak association became a delivered title. Padding
+now draws only from candidates that are genuinely related, so **a row may come up short** — four
+titles that fit beat ten where six are filler. The run log says so, naming the closest rejected
+title, so a short row reads as the filter working rather than a failure.
+
+### Where every pick came from
+
+Each pick records the source that surfaced it and how strongly that source vouched, shown under the
+title:
+
+```
+#3  The Sandman — Because you watched The Pitt
+    suggested by TMDB · loosely related
+```
+
+Nothing claims a strength it didn't measure: sources that don't rank their suggestions say only who
+suggested it. The run log carries the same per row at DEBUG — every pick with its seed, source and
+affinity — so a "why did it pick that?" report is answerable from a downloaded log.
+
+### Also
+
+- Release tags now publish `:dev` as well as `:latest` and the version tag — a tag is cut from
+  `dev`, so `:dev` was being left a build behind.
+
 ## [0.1.0-beta.2] - 2026-07-22
 
 Second beta. Mostly the things the first beta's users ran into.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # ---- web build ------------------------------------------------------------------
-FROM node:22-alpine AS web
+# --platform=$BUILDPLATFORM: the web build emits static files, which are identical whatever the
+# target architecture — so it runs natively on the builder instead of once per platform under QEMU.
+# Emulating a pnpm build for arm64 cost minutes and produced byte-identical output.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS web
 WORKDIR /build
 RUN corepack enable
 # pnpm-workspace.yaml carries the approved build scripts (esbuild); without it pnpm 10
@@ -19,12 +22,25 @@ RUN apt-get update \
 
 WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
-COPY shortlist/ ./shortlist/
-# Bundle every LLM provider SDK — the container is the whole product, so the curator must work
-# for whichever provider the owner picks in setup without them shelling in to pip install extras.
-# (ollama/none need no SDK.) `posters` (Pillow) powers uploaded-poster normalization; OpenAI/Google
+
+# DEPENDENCIES FIRST, from pyproject alone — this layer must not see application source, or every
+# commit reinstalls FastAPI, SQLAlchemy and three LLM SDKs from scratch on BOTH architectures. The
+# stub package exists only so hatchling can read `__version__` and resolve the dependency set; the
+# real source arrives in the next layer and is installed over it with --no-deps.
+#
+# Bundle every LLM provider SDK — the container is the whole product, so the curator must work for
+# whichever provider the owner picks in setup without them shelling in to pip install extras.
+# (local/none need no SDK.) `posters` (Pillow) powers uploaded-poster normalization; OpenAI/Google
 # also generate poster images, reusing the curator key.
-RUN pip install --no-cache-dir ".[anthropic,openai,google,posters]"
+RUN mkdir -p shortlist \
+    && printf '__version__ = "0.0.0"\n' > shortlist/__init__.py \
+    && pip install --no-cache-dir ".[anthropic,openai,google,posters]" \
+    && rm -rf shortlist
+
+COPY shortlist/ ./shortlist/
+# --no-deps: everything it needs is already in the layer above, so a source-only change reinstalls
+# just this package (seconds) instead of the whole dependency tree.
+RUN pip install --no-cache-dir --no-deps .
 
 COPY --from=web /build/dist ./web/dist
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -185,6 +185,33 @@ revoking (`DELETE /api/system/api-token`) invalidates the old token immediately.
 curl -H "Authorization: Bearer <token>" https://<host>/api/runs
 ```
 
+## How a pick is chosen (and why a row can be short)
+
+Every candidate carries an **affinity** — how strongly the source that produced it vouched for it,
+0..1:
+
+- **TMDB** sets it from which endpoint suggested the title and how near the top of that list it sat
+  (`/recommendations` is worth more than `/similar`, and both decay down their list), multiplied by
+  a **genre-coherence** factor: the share of the candidate's own genres that the seed does not have.
+  TMDB tags a medical drama simply "Drama" and so is nearly everything it suggests, so overlap alone
+  discriminates nothing — but a suggestion also tagged "Sci-Fi & Fantasy" is measurably further away.
+- **Sources with no ranking of their own** — `tmdb_discover`, `trakt`, `llm_library`, `llm_web` —
+  report the neutral `1.0`. That means "no ranking information", not "perfect match"; they are
+  deliberate picks rather than the tail of a list, and `pre_rank`'s per-source round-robin is what
+  keeps them competing fairly.
+
+Ranking is `(1 + seed_frequency) × rating × (1 + seed_weight) × affinity`, so a well-rated but
+distant title no longer beats an obviously similar one.
+
+**A row is allowed to come up short.** Padding a partly-filled row only draws from candidates at or
+above `MIN_FILLER_AFFINITY` (0.35) — four genuinely-similar titles beat ten where six are filler.
+When that happens the run log says so at INFO, naming the closest rejected title, so a short row
+reads as the filter working rather than as a failure.
+
+Each delivered pick records its provenance (`sources`, `affinity`, returned by `GET /api/users` and
+the run detail) and the UI shows it under the title — *"suggested by TMDB · loosely related"*. At
+DEBUG the run log prints the same per row: every pick with its seed, source and affinity.
+
 ## How rows stay private
 
 Each row is a Plex collection labelled `shortlist_<userslug>`. Every _other_ account's share filter

--- a/shortlist/__init__.py
+++ b/shortlist/__init__.py
@@ -1,3 +1,3 @@
 """Shortlist — a private, AI-curated "Picked for You" row for every user on your Plex server."""
 
-__version__ = "0.1.0b2"
+__version__ = "0.1.0b3"

--- a/shortlist/engine/candidates.py
+++ b/shortlist/engine/candidates.py
@@ -172,6 +172,35 @@ def _web_via_search(
     return titles
 
 
+def _seed_genre_ids(tmdb: TmdbClient, seed: Seed) -> set[int]:
+    """The seed's own genres, for `genre_coherence`. Cached by the client; a failure just means
+    "no opinion" — never a dead source."""
+    try:
+        return set(tmdb.genre_ids_for(seed.tmdb_id, seed.media_type))
+    except Exception as e:
+        logger.debug("could not read genres for seed {} ({})", seed.title, type(e).__name__)
+        return set()
+
+
+def genre_coherence(seed_genre_ids: set[int], candidate_genre_ids: list[int]) -> float:
+    """How much a candidate stays inside the seed's genres, 0.5..1.0.
+
+    Position in TMDB's list is not enough on its own. `The Pitt` is tagged simply "Drama", and so is
+    almost everything it suggests — but Torchwood and The Sandman are ALSO "Sci-Fi & Fantasy", and
+    that foreign genre is the whole difference between a medical drama and a fantasy series. TMDB
+    still recommends them, fairly high up; nothing in position or rating says they don't belong.
+
+    Measured on genres the candidate has that the seed does NOT, as a share of its own genres — not
+    on overlap, which cannot discriminate when every title shares the one broad genre. Floored at
+    0.5 so this shades the ranking rather than dominating it, and returns 1.0 (no opinion) whenever
+    either side has no genres recorded.
+    """
+    if not seed_genre_ids or not candidate_genre_ids:
+        return 1.0
+    foreign = set(candidate_genre_ids) - seed_genre_ids
+    return 1.0 - 0.5 * (len(foreign) / len(set(candidate_genre_ids)))
+
+
 def gather_candidates(
     tmdb: TmdbClient,
     seeds: list[Seed],
@@ -208,7 +237,13 @@ def gather_candidates(
             genre_maps[media_type] = tmdb.genre_names(media_type)
         return genre_maps[media_type]
 
-    def add(item: dict, media_type: MediaType, source: str) -> Candidate:
+    # The best MEASURED affinity per title. Kept separately from `Candidate.affinity` because the
+    # field's default (1.0) is "no ranking information", which is indistinguishable from a source
+    # claiming a perfect match — so a title that tmdb_discover also found would otherwise have its
+    # measured position overwritten by that neutral default and sail back to the top of the row.
+    measured: dict[tuple[int, MediaType], float] = {}
+
+    def add(item: dict, media_type: MediaType, source: str, affinity: float | None = None) -> Candidate:
         key = (item["id"], media_type)
         if key not in pool:
             date = item.get("release_date") or item.get("first_air_date") or ""
@@ -222,8 +257,13 @@ def gather_candidates(
                 rating=float(item.get("vote_average") or 0.0),
                 vote_count=int(item.get("vote_count") or 0),
             )
-        # A title two sources both found belongs to both — it competes in each one's share.
+        # A title two sources both found belongs to both — it competes in each one's share, and
+        # keeps the STRONGEST claim any of them made for it. A source with nothing to claim
+        # (`affinity is None`) adds itself to `sources` but never touches the score.
         pool[key].sources.add(source)
+        if affinity is not None:
+            measured[key] = max(measured.get(key, 0.0), affinity)
+            pool[key].affinity = measured[key]
         return pool[key]
 
     def merge(tmdb_id: int, title: str, media_type: MediaType, year, genres, source: str) -> Candidate:
@@ -245,8 +285,10 @@ def gather_candidates(
         attempted.add("tmdb_similar")
         try:
             for seed in seeds:
-                for item in tmdb.suggestions(seed.tmdb_id, seed.media_type):
-                    add(item, seed.media_type, "tmdb_similar").seeds.append(seed)
+                seed_genres = _seed_genre_ids(tmdb, seed)
+                for item, affinity in tmdb.suggestions(seed.tmdb_id, seed.media_type):
+                    coherence = genre_coherence(seed_genres, item.get("genre_ids") or [])
+                    add(item, seed.media_type, "tmdb_similar", affinity * coherence).seeds.append(seed)
         except Exception as e:
             # The only source that used to have no isolation: a TMDB hiccup here killed the user's
             # whole run, discarding the pools every other source had already gathered.

--- a/shortlist/engine/clients/tmdb.py
+++ b/shortlist/engine/clients/tmdb.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Protocol
+from typing import ClassVar, Protocol
 from urllib.parse import urlencode
 
 from loguru import logger
@@ -63,16 +63,39 @@ class TmdbClient:
     def ping(self) -> bool:
         return bool(self._get("/configuration"))
 
-    def suggestions(self, tmdb_id: int, media_type: MediaType) -> list[dict]:
-        """Pooled /recommendations + /similar results for one seed title."""
+    # How much each endpoint's vouching is worth, and how fast that decays down its list.
+    #
+    # `/recommendations` is built from what people actually watch together and is reliably good at
+    # the top; `/similar` is genre+keyword matching and gets noisy fast — for "The Pitt" (a medical
+    # drama) it returns Torchwood and The Sandman partway down. Pooling the two and forgetting where
+    # each title sat cost us the whole signal: position IS the similarity claim, and without it the
+    # only thing left to rank on was TMDB's average rating, which is how a well-rated but unrelated
+    # show beat an obviously-similar one.
+    _ENDPOINT_WEIGHT: ClassVar[dict[str, float]] = {"recommendations": 1.0, "similar": 0.6}
+    _POSITION_DECAY = 0.5  # the bottom of a list is worth half its top
+
+    def suggestions(self, tmdb_id: int, media_type: MediaType) -> list[tuple[dict, float]]:
+        """Pooled /recommendations + /similar for one seed, each with an affinity in (0, 1].
+
+        Affinity is "how strongly TMDB vouched for this title for this seed": which endpoint it came
+        from, and how near the top of that endpoint's list it sat. A title both endpoints return
+        keeps the better of the two.
+
+        Returns:
+            ``(item, affinity)`` pairs, best first.
+        """
         kind = "movie" if media_type is MediaType.MOVIE else "tv"
-        pooled: dict[int, dict] = {}
-        for endpoint in ("recommendations", "similar"):
-            data = self._get(f"/{kind}/{tmdb_id}/{endpoint}")
-            for item in data.get("results", []):
-                pooled.setdefault(item["id"], item)
+        pooled: dict[int, tuple[dict, float]] = {}
+        for endpoint, weight in self._ENDPOINT_WEIGHT.items():
+            results = self._get(f"/{kind}/{tmdb_id}/{endpoint}").get("results", [])
+            last = max(len(results) - 1, 1)
+            for position, item in enumerate(results):
+                affinity = weight * (1 - self._POSITION_DECAY * position / last)
+                previous = pooled.get(item["id"])
+                if previous is None or affinity > previous[1]:
+                    pooled[item["id"]] = (item, affinity)
         logger.debug("TMDB suggestions for {} {}: {} pooled", kind, tmdb_id, len(pooled))
-        return list(pooled.values())
+        return sorted(pooled.values(), key=lambda pair: -pair[1])
 
     def search(self, title: str, media_type: MediaType, *, year: int | None = None) -> dict | None:
         """Resolve a free-text title to its best TMDB match, or None if nothing matches.

--- a/shortlist/engine/curator/base.py
+++ b/shortlist/engine/curator/base.py
@@ -357,6 +357,8 @@ def validate_picks(
                 media_type=c.media_type,
                 seed_tmdb_id=seed.tmdb_id if seed else None,
                 seed_title=seed.title if seed else None,
+                sources=sorted(c.sources),
+                affinity=c.affinity,
             )
         )
         if len(picks) == k:

--- a/shortlist/engine/curator/null.py
+++ b/shortlist/engine/curator/null.py
@@ -29,6 +29,11 @@ class NullCurator:
                     media_type=c.media_type,
                     seed_tmdb_id=seed.tmdb_id if seed else None,
                     seed_title=seed.title if seed else None,
+                    # Carried like every other curator does (see `validate_picks`). This is the
+                    # DEFAULT curator, so forgetting it here would leave most installs with no
+                    # record of where any of their picks came from.
+                    sources=sorted(c.sources),
+                    affinity=c.affinity,
                 )
             )
         return picks

--- a/shortlist/engine/models.py
+++ b/shortlist/engine/models.py
@@ -88,6 +88,13 @@ class Candidate:
     # llm_library, llm_web) would otherwise be crowded out wholesale by the seeded ones — see
     # ranking.pre_rank, which gives each source a fair share of the pool it hands the curator.
     sources: set[str] = field(default_factory=set)
+    # How strongly the source that produced it vouched for it, 0..1. TMDB sets this from which
+    # endpoint suggested the title and how near the top of that list it sat — the similarity signal
+    # that used to be discarded. Sources with no ranking of their own (discover, Trakt, the LLM
+    # sources) keep the neutral 1.0: they are deliberate picks, not the tail of a list, and
+    # penalising them for lacking a signal they never had is what `pre_rank`'s round-robin exists to
+    # prevent. A title several seeds suggested keeps the strongest claim any of them made.
+    affinity: float = 1.0
 
     @property
     def seed_frequency(self) -> int:
@@ -123,6 +130,11 @@ class Pick:
     # section key, `library` its display name ("Movies") for the report label.
     section_key: str = ""
     library: str = ""
+    # Which candidate source(s) surfaced this title, and how strongly they vouched for it. Carried
+    # all the way to the UI so "why is this here?" is answerable without reading a log: a pick that
+    # came from the tail of TMDB's list should LOOK different to one an LLM chose deliberately.
+    sources: list[str] = field(default_factory=list)
+    affinity: float = 1.0
 
 
 @dataclass

--- a/shortlist/engine/privacy.py
+++ b/shortlist/engine/privacy.py
@@ -263,14 +263,14 @@ def sync_user_restrictions(
             filters=dict(remote.filters),
         )
         if dry_run:
-            logger.info("[dry-run] {}: would snapshot filters {}", user.username, snapshot.filters)
+            logger.info("[dry-run] {}: would snapshot filters before the first write", user.username)
         else:
             snapshots.save(snapshot)
             logger.info("{}: snapshot persisted before first restriction write", user.username)
 
     diff = {k: (remote.filters[k], v) for k, v in desired_fields.items()}
     if dry_run:
-        logger.info("[dry-run] {}: would merge filters {}", user.username, diff)
+        logger.info("[dry-run] {}: would merge filters — {}", user.username, summarise_filter_diff(diff, label_prefix))
         return diff
 
     plextv.update_user_filters(user.plex_account_id, desired_fields)
@@ -279,8 +279,37 @@ def sync_user_restrictions(
     # ONCE after all writes and verifies every written account's shortlist excludes persisted, still
     # strictly before any promotion — see the batched read-back at the end of _privacy_sync_phase in
     # pipeline.py (plex-safety rule 1).
-    logger.info("{}: filters merged {}", user.username, diff)
+    logger.info("{}: filters merged — {}", user.username, summarise_filter_diff(diff, label_prefix))
     return diff
+
+
+def summarise_filter_diff(diff: dict[str, tuple[str, str]], label_prefix: str) -> str:
+    """A one-line description of what a filter write actually CHANGED.
+
+    The full before/after belongs in the audit event (rule 10), not in the log: on a 48-user server
+    each account's filter string carries every other account's exclude, so logging both sides put
+    ~8 KB per user per field into the file. Forty-eight of those buried everything else in the run,
+    which is the opposite of what the log is for — and it is the same 47 labels every time, so the
+    only information in it is the one that changed.
+    """
+    parts = []
+    for fieldname, (before, after) in sorted(diff.items()):
+        was = shortlist_labels_in(before, label_prefix)
+        now = shortlist_labels_in(after, label_prefix)
+        added, removed = sorted(now - was), sorted(was - now)
+        if not added and not removed:
+            # A change outside our own excludes (pruning a shared row's label leaves the set equal).
+            parts.append(f"{fieldname} rewritten")
+            continue
+        bits = []
+        for sign, labels in (("+", added), ("-", removed)):
+            if not labels:
+                continue
+            shown = ", ".join(labels[:3])
+            more = f" +{len(labels) - 3} more" if len(labels) > 3 else ""
+            bits.append(f"{sign}{len(labels)} ({shown}{more})")
+        parts.append(f"{fieldname} {' '.join(bits)}")
+    return "; ".join(parts) or "no change"
 
 
 def restore_user_restrictions(
@@ -297,7 +326,8 @@ def restore_user_restrictions(
     if not changed:
         return False
     if dry_run:
-        logger.info("[dry-run] {}: would restore filters {}", snapshot.username, changed)
+        # Field names only: a restore payload is the user's ENTIRE original filter string per field.
+        logger.info("[dry-run] {}: would restore {} from the snapshot", snapshot.username, ", ".join(sorted(changed)))
         return True
     plextv.update_user_filters(snapshot.plex_account_id, changed)
     readback = plextv.get_user(snapshot.plex_account_id)

--- a/shortlist/engine/ranking.py
+++ b/shortlist/engine/ranking.py
@@ -5,7 +5,11 @@ Two rules, both learned the hard way:
 1. Seed provenance ADDS to a title's score, it does not multiply it. When the score was
    ``seed_frequency x rating x weight``, every candidate from a seedless source — tmdb_discover,
    llm_library, llm_web — scored exactly 0 and sorted below the worst seeded title on the list.
-2. Each source gets a fair SHARE of the pool handed to the curator. Ranking alone cannot fix this:
+2. Rating is not similarity. Without `affinity` the only thing separating two single-seed
+   candidates was TMDB's average vote — so a well-rated but unrelated show beat an obviously
+   similar one, and a row seeded by a medical drama filled up with fantasy and sci-fi. Affinity
+   carries "how near the top of TMDB's list for THIS seed was it", which is the actual claim.
+3. Each source gets a fair SHARE of the pool handed to the curator. Ranking alone cannot fix this:
    30 seeds x TMDB suggestions is hundreds of seeded candidates, so a single global sort fills
    every slot with tmdb_similar however good the rest are, and the other sources — including the
    LLM calls we paid for — never reach the curator at all.
@@ -27,7 +31,7 @@ def score(candidate: Candidate) -> float:
     """
     seed_weight = max((s.weight for s in candidate.seeds), default=0.0)
     rating = candidate.rating or 5.0  # unrated titles get a neutral prior, not zero
-    return (1 + candidate.seed_frequency) * rating * (1.0 + seed_weight)
+    return (1 + candidate.seed_frequency) * rating * (1.0 + seed_weight) * candidate.affinity
 
 
 def _sort_key(candidate: Candidate) -> tuple:

--- a/shortlist/engine/rows.py
+++ b/shortlist/engine/rows.py
@@ -782,6 +782,7 @@ def _run_user(
                 # rest from its fresh candidates. (At pct == 0 the pool already dropped finished ones.)
                 sec_picks = _apply_watched_cap(sec_picks, sub, watched_titles, k, pct)
             section_picks[section.key] = [replace(p, rank=i + 1) for i, p in enumerate(sec_picks[:k])]
+            _log_row_provenance(user, spec, section, section_picks[section.key], sub, k)
         # Stamp each pick with the row AND the library it belongs to, so the user page can group picks
         # per row and the effectiveness report can split a multi-library row into one line per library.
         library_names = {section.key: getattr(section, "title", "") or "" for section in targets}
@@ -1088,12 +1089,73 @@ def _shared_row(
     return agg if picks else None
 
 
+# Below this, a title is in the pool because TMDB mentioned it somewhere near the bottom of a list,
+# not because it resembles anything the person watched. A row of four genuinely-similar titles is
+# worth more than ten where six are filler — and filler is what a beta user saw when a medical drama
+# produced The Sandman, Servant and Torchwood, each captioned "Because you watched The Pitt".
+# Sources with no ranking of their own sit at the neutral 1.0 and so are never filtered out here.
+MIN_FILLER_AFFINITY = 0.35
+
+
+def _log_row_provenance(
+    user: UserProfile,
+    spec: RowSpec,
+    section,
+    picks: list[Pick],
+    pool: list[Candidate],
+    wanted: int,
+) -> None:
+    """Explain a finished row in the log: what went in, and what was rejected as too loose.
+
+    A beta user reported a medical-drama row full of fantasy, and answering "why?" meant querying
+    TMDB by hand — nothing in the log said where any pick came from or how strong the claim was. One
+    DEBUG block per row makes the same question answerable from a downloaded log.
+    """
+    label = f"{user.username}/{spec.slug}@{getattr(section, 'title', '?')}"
+    if not picks:
+        logger.debug("{}: no picks — {} candidates, none worth delivering", label, len(pool))
+        return
+    logger.debug("{}: {} picks from {} candidates (row size {})", label, len(picks), len(pool), wanted)
+    for pick in picks:
+        logger.debug(
+            "  #{} {} — {} · {} · affinity {:.2f}",
+            pick.rank,
+            pick.title,
+            f"seed {pick.seed_title}" if pick.seed_title else "no seed",
+            "+".join(pick.sources) or "source not recorded",
+            pick.affinity,
+        )
+    if len(picks) < wanted:
+        # The row is deliberately short: `_pad_picks` refused to fill it from the tail. Say so, or
+        # it reads as a bug — a short row is the fix working, not the pipeline failing.
+        too_loose = [c for c in pool if c.affinity < MIN_FILLER_AFFINITY]
+        logger.info(
+            "{}: row is {} short of {} — {} candidate(s) were too loosely related to deliver{}",
+            label,
+            wanted - len(picks),
+            wanted,
+            len(too_loose),
+            f" (closest rejected: {max(too_loose, key=lambda c: c.affinity).title})" if too_loose else "",
+        )
+
+
 def _pad_picks(picks: list[Pick], ranked: list[Candidate], k: int) -> list[Pick]:
-    """Top up short curator output from the heuristic order (never invents titles)."""
+    """Top up short curator output from the heuristic order (never invents titles).
+
+    Only from candidates whose source actually vouched for them: padding is where a weak association
+    turns into a delivered row, so the row is allowed to come up short instead.
+    """
     have = {(p.tmdb_id, p.media_type) for p in picks}  # movie 1399 and TV 1399 are different titles
+    worth_it = [c for c in ranked if c.affinity >= MIN_FILLER_AFFINITY]
+    if len(worth_it) < len(ranked):
+        logger.debug(
+            "padding: {} of {} candidates were too loosely related to deliver",
+            len(ranked) - len(worth_it),
+            len(ranked),
+        )
     fillers = NullCurator().curate(
         UserProfile(username="", plex_account_id=0, user_type=UserType.SHARED),
-        [c for c in ranked if (c.tmdb_id, c.media_type) not in have],
+        [c for c in worth_it if (c.tmdb_id, c.media_type) not in have],
         k - len(picks),
     )
     out = list(picks)
@@ -1130,6 +1192,7 @@ def _cold_start_picks(ctx: EngineContext, user: UserProfile, cfg: EngineConfig, 
                     rank=len(picks) + 1,
                     reason="Popular on this server",
                     media_type=kind,
+                    sources=["cold_start"],  # no history to work from — say so rather than imply a match
                 )
             )
     return picks

--- a/shortlist/server/api/runs.py
+++ b/shortlist/server/api/runs.py
@@ -110,7 +110,14 @@ async def get_run(run_id: int, request: Request) -> dict:
                     "exa_searches": run_user.exa_searches,
                     "diff": run_user.diff or {},
                     "picks": [
-                        {"rank": p.rank, "title": p.title, "reason": p.reason, "seed_title": p.seed_title}
+                        {
+                            "rank": p.rank,
+                            "title": p.title,
+                            "reason": p.reason,
+                            "seed_title": p.seed_title,
+                            "sources": [s for s in (p.sources or "").split(",") if s],
+                            "affinity": p.affinity,
+                        }
                         for p in picks
                     ],
                     # Per-(row, library) breakdown; [] on legacy runs -> UI falls back to diff + picks.

--- a/shortlist/server/api/users.py
+++ b/shortlist/server/api/users.py
@@ -44,6 +44,10 @@ def _pick_dict(pick: PickRow) -> dict:
         "media_type": pick.media_type,
         "collection_slug": pick.collection_slug or DEFAULT_SLUG,  # legacy blank rows are the default row
         "seed_title": pick.seed_title,
+        # Provenance: which source(s) surfaced it, and how strongly they vouched. Blank/1.0 on rows
+        # written before 0035, which the UI renders as "not recorded" rather than "a perfect match".
+        "sources": [s for s in (pick.sources or "").split(",") if s],
+        "affinity": pick.affinity,
     }
 
 

--- a/shortlist/server/db/alembic/versions/0035_pick_provenance.py
+++ b/shortlist/server/db/alembic/versions/0035_pick_provenance.py
@@ -1,0 +1,33 @@
+"""Record where each pick came from, and how strongly its source vouched for it
+
+A beta user's medical-drama row filled up with fantasy and sci-fi, and answering "why?" meant
+querying TMDB by hand and reading the ranking code. The pool already knew — `Candidate.sources` and
+the new `affinity` — but none of it survived into the pick, so the UI could only ever say "Because
+you watched X" with no indication of how strong that claim was.
+
+Existing rows keep the neutral defaults: blank sources ("we didn't record it") and affinity 1.0, so
+old picks are never rendered as though they were weak matches.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    columns = {c["name"] for c in sa.inspect(op.get_bind()).get_columns("picks")}
+    if "sources" not in columns:
+        op.add_column("picks", sa.Column("sources", sa.String(length=255), nullable=False, server_default=""))
+    if "affinity" not in columns:
+        op.add_column("picks", sa.Column("affinity", sa.Float(), nullable=False, server_default="1.0"))
+
+
+def downgrade() -> None:
+    columns = {c["name"] for c in sa.inspect(op.get_bind()).get_columns("picks")}
+    for name in ("sources", "affinity"):
+        if name in columns:
+            op.drop_column("picks", name)

--- a/shortlist/server/db/models.py
+++ b/shortlist/server/db/models.py
@@ -243,6 +243,11 @@ class PickRow(Base):
     library: Mapped[str] = mapped_column(String(255), default="")
     title: Mapped[str] = mapped_column(String(512), default="")
     reason: Mapped[str] = mapped_column(String(255), default="")
+    # Provenance, so "why is this here?" is answerable from the UI: which source(s) surfaced the
+    # title, and how strongly they vouched for it (1.0 = top of TMDB's list for that seed, or a
+    # source with no ranking of its own). Comma-separated source ids; blank on pre-0035 rows.
+    sources: Mapped[str] = mapped_column(String(255), default="")
+    affinity: Mapped[float] = mapped_column(Float, default=1.0)
     seed_tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     seed_title: Mapped[str | None] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/shortlist/server/services/context_builder.py
+++ b/shortlist/server/services/context_builder.py
@@ -353,6 +353,11 @@ class ContextBuilder:
                     rank=r.rank,
                     reason=r.reason,
                     media_type=MediaType(r.media_type),
+                    # Carried, or provenance would survive exactly one night: on a non-refresh night
+                    # the pick comes back through here, and rebuilding it without these would blank
+                    # the UI's "suggested by …" line and re-persist it as "not recorded".
+                    sources=[part for part in (r.sources or "").split(",") if part],
+                    affinity=r.affinity,
                     seed_tmdb_id=r.seed_tmdb_id,
                     seed_title=r.seed_title,
                     collection_slug=r.collection_slug,

--- a/shortlist/server/services/run_service.py
+++ b/shortlist/server/services/run_service.py
@@ -496,6 +496,8 @@ class RunService:
                         library=pick.library,
                         title=pick.title,
                         reason=pick.reason,
+                        sources=",".join(pick.sources),
+                        affinity=pick.affinity,
                         seed_tmdb_id=pick.seed_tmdb_id,
                         seed_title=pick.seed_title,
                     )

--- a/tests/integration/test_engine_vs_fake.py
+++ b/tests/integration/test_engine_vs_fake.py
@@ -169,6 +169,21 @@ def test_engine_run_end_to_end(fakes, tmp_path):
     report = engine_run(ctx, users)
 
     assert report.ok, [(u.username, u.error) for u in report.users]
+
+    # Provenance survives the whole pipeline — candidate source -> ranking -> curator -> Pick.
+    # Asserted here rather than in a unit test because every link in that chain is real: the actual
+    # TmdbClient calling the actual /recommendations and /similar endpoints, then the actual ranking.
+    delivered = [p for u in report.users for p in u.picks]
+    assert delivered, "nothing was delivered, so provenance proves nothing"
+    for pick in delivered:
+        assert pick.sources, f"{pick.title} reached the row with no record of what suggested it"
+        assert 0 < pick.affinity <= 1.0, f"{pick.title} has a nonsense affinity {pick.affinity}"
+    seeded = [p for p in delivered if "tmdb_similar" in p.sources]
+    assert seeded, "the TMDB source produced nothing, so affinity was never exercised"
+    assert any(p.affinity < 1.0 for p in seeded), (
+        "every TMDB pick scored a perfect 1.0 — position is being discarded again, which is the "
+        "exact bug that filled a medical-drama row with fantasy"
+    )
     by_slug = {u.slug: u for u in report.users}
     assert by_slug["sarah"].status == "ok"
     assert by_slug["mike"].status == "ok"

--- a/tests/unit/test_candidates.py
+++ b/tests/unit/test_candidates.py
@@ -1,6 +1,14 @@
 from types import SimpleNamespace
 
-from shortlist.engine.candidates import GatherStats, _slice_for_llm, filter_candidates, gather_candidates
+import pytest
+
+from shortlist.engine.candidates import (
+    GatherStats,
+    _slice_for_llm,
+    filter_candidates,
+    gather_candidates,
+    genre_coherence,
+)
 from shortlist.engine.clients.search import SearchResult
 from shortlist.engine.curator import NullCurator
 from shortlist.engine.curator.base import parse_web_titles
@@ -53,12 +61,27 @@ def seed(tmdb_id: int, title: str = "Seed") -> Seed:
     return Seed(tmdb_id=tmdb_id, title=title, media_type=MediaType.MOVIE, weight=1.0)
 
 
+def _ranked(items: list[dict], affinity: float = 1.0) -> list[tuple[dict, float]]:
+    """`TmdbClient.suggestions` returns (item, affinity) pairs — affinity being how near the top of
+    TMDB's list the title sat. These tests predate that and don't care, so they use the neutral 1.0.
+    """
+    return [(item, affinity) for item in items]
+
+
 class TestGatherCandidates:
     def test_pools_and_tags_with_all_suggesting_seeds(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 42, "title": "Shared Pick", "genre_ids": [18], "vote_average": 8.0, "release_date": "2020-01-01"},
-            {"id": 42 + tid, "title": f"Only {tid}", "genre_ids": [], "vote_average": 6.0},
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [
+                {
+                    "id": 42,
+                    "title": "Shared Pick",
+                    "genre_ids": [18],
+                    "vote_average": 8.0,
+                    "release_date": "2020-01-01",
+                },
+                {"id": 42 + tid, "title": f"Only {tid}", "genre_ids": [], "vote_average": 6.0},
+            ]
+        )
         pool = gather_candidates(mock_tmdb, [seed(1), seed(2)])
         shared = next(c for c in pool if c.tmdb_id == 42)
         assert shared.seed_frequency == 2
@@ -71,9 +94,11 @@ class TestGatherCandidates:
         # under each, so the parts can exceed the unique total.
         from loguru import logger
 
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 42, "title": "Both", "genre_ids": [], "vote_average": 8.0},
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [
+                {"id": 42, "title": "Both", "genre_ids": [], "vote_average": 8.0},
+            ]
+        )
         trakt = _FakeTrakt([{"tmdb_id": 42, "title": "Both", "year": 2020, "genres": []}])
 
         lines: list[str] = []
@@ -93,9 +118,9 @@ class TestGatherCandidates:
         assert mock_tmdb.genre_names.call_count == 1
 
     def test_discover_source_widens_the_pool_with_taste_genres(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 100, "title": "Similar", "genre_ids": [18], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 100, "title": "Similar", "genre_ids": [18], "vote_average": 7.0}]
+        )
         mock_tmdb.genre_ids_for.side_effect = lambda tid, mt: [18, 28]
         mock_tmdb.discover.side_effect = lambda mt, gids, **kw: [
             {"id": 200, "title": "Discovered", "genre_ids": [18], "vote_average": 8.5}
@@ -115,9 +140,9 @@ class TestGatherCandidates:
         assert {c.tmdb_id for c in pool} == {5}
 
     def test_discover_failure_keeps_the_similar_pool(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "Similar", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "Similar", "genre_ids": [], "vote_average": 7.0}]
+        )
         mock_tmdb.genre_ids_for.side_effect = lambda tid, mt: [18]
         mock_tmdb.discover.side_effect = RuntimeError("TMDB 503")
         # Discover blows up, but it's only a "widen" source — the tmdb_similar pool must survive.
@@ -125,9 +150,9 @@ class TestGatherCandidates:
         assert {c.tmdb_id for c in pool} == {1}
 
     def test_empty_sources_falls_back_to_default(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "Similar", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "Similar", "genre_ids": [], "vote_average": 7.0}]
+        )
         # Toggling every source off still yields the baseline, never an empty pool.
         pool = gather_candidates(mock_tmdb, [seed(1)], sources=[])
         assert {c.tmdb_id for c in pool} == {1}
@@ -138,7 +163,7 @@ class TestGatherCandidates:
         assert mock_tmdb.discover.called is False
 
     def test_llm_library_source_proposes_owned_titles(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         catalog = {
             MediaType.MOVIE: [
                 {"tmdb_id": 500, "rating_key": 1, "title": "Owned A", "year": 2020, "genres": ["Drama"]},
@@ -156,9 +181,9 @@ class TestGatherCandidates:
         assert {c.tmdb_id for c in pool} == {500}  # only the curator's pick from the owned library
 
     def test_llm_library_failure_keeps_the_other_sources(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         catalog = {MediaType.MOVIE: [{"tmdb_id": 5, "rating_key": 1, "title": "X", "year": 2020, "genres": []}]}
         pool = gather_candidates(
             mock_tmdb,
@@ -171,9 +196,9 @@ class TestGatherCandidates:
         assert {c.tmdb_id for c in pool} == {1}  # similar survives; the LLM source's failure is swallowed
 
     def test_llm_library_is_a_noop_without_a_real_curator(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         catalog = {MediaType.MOVIE: [{"tmdb_id": 5, "rating_key": 1, "title": "X", "year": 2020, "genres": []}]}
         # NullCurator isn't AI -> the source no-ops (matches the UI gate); only tmdb_similar contributes.
         pool = gather_candidates(
@@ -187,7 +212,7 @@ class TestGatherCandidates:
         assert {c.tmdb_id for c in pool} == {1}
 
     def test_trakt_source_adds_related_titles(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         trakt = _FakeTrakt([{"tmdb_id": 700, "title": "Related", "year": 2019, "genres": ["drama"]}])
         s = seed(1)
         pool = gather_candidates(mock_tmdb, [s], sources=["trakt"], trakt=trakt)
@@ -197,9 +222,9 @@ class TestGatherCandidates:
         assert s in cand.seeds  # provenance kept — this is a real "because you watched X"
 
     def test_trakt_failure_keeps_the_other_sources(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
 
         class _Boom:
             def related(self, *a):
@@ -209,7 +234,7 @@ class TestGatherCandidates:
         assert {c.tmdb_id for c in pool} == {1}
 
     def test_llm_web_source_resolves_proposed_titles_via_tmdb_search(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         mock_tmdb.genre_names.return_value = {}
         # A movie resolves, a SHOW resolves, and a hallucinated title doesn't (so it's dropped).
         resolved = {
@@ -236,9 +261,9 @@ class TestGatherCandidates:
         assert next(c for c in pool if c.tmdb_id == 900).media_type is MediaType.SHOW
 
     def test_llm_web_is_a_noop_without_a_real_curator(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         # NullCurator has no web search -> the source no-ops (matching the UI gate); search never runs.
         pool = gather_candidates(
             mock_tmdb, [seed(1)], sources=["tmdb_similar", "llm_web"], curator=NullCurator(), profile=object()
@@ -247,9 +272,9 @@ class TestGatherCandidates:
         assert not mock_tmdb.search.called
 
     def test_llm_web_failure_keeps_the_other_sources(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
 
         class _Boom:
             supports_native_web_search = True
@@ -313,7 +338,7 @@ class TestLlmWebBackends:
     """The auto|native|exa backend matrix for the llm_web source (public-app: works on every provider)."""
 
     def _tmdb(self, mock_tmdb, resolved):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         mock_tmdb.genre_names.return_value = {}
         mock_tmdb.search.side_effect = lambda title, mt, year=None: resolved.get(title)
         return mock_tmdb
@@ -380,9 +405,9 @@ class TestLlmWebBackends:
     def test_native_mode_without_a_native_provider_is_a_noop_not_a_failure(self, mock_tmdb):
         """web_search_mode=native + Ollama: the source can't run, so it's skipped — the OTHER source
         still contributes and no phantom 'source failed' is raised (attempted must not include it)."""
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         search = _FakeSearch([make_result("x", "y")])
         curator = _NonNativeCurator("[]")
 
@@ -400,9 +425,9 @@ class TestLlmWebBackends:
 
     def test_blocked_when_no_native_and_no_search(self, mock_tmdb):
         """auto + non-native provider + NO Exa key: llm_web simply can't run; tmdb_similar carries it."""
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 2, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 2, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         curator = _NonNativeCurator("[]")
         pool = gather_candidates(
             mock_tmdb,
@@ -418,9 +443,9 @@ class TestLlmWebBackends:
     def test_exa_mode_without_a_search_key_is_a_noop_not_a_failure(self, mock_tmdb):
         """web_search_mode=exa but no Exa client configured: llm_web can't run, so it's skipped and
         never registers as attempted — tmdb_similar still carries the pool, no phantom failure."""
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 3, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 3, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         curator = _NativeCurator()  # native-capable, but exa mode forces the (absent) Exa backend
         pool = gather_candidates(
             mock_tmdb,
@@ -437,9 +462,9 @@ class TestLlmWebBackends:
     def test_heuristic_curator_never_runs_llm_web_even_with_a_search_key(self, mock_tmdb):
         """The engine mirror of the frontend gate: NullCurator (heuristic mode) has no model to pick
         titles, so llm_web contributes nothing even with an Exa key — and doesn't false-fail the run."""
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 4, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 4, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         search = _FakeSearch([make_result("2024 picks", "Dune")])
         pool = gather_candidates(
             mock_tmdb,
@@ -472,7 +497,7 @@ class TestPerTitleWebSearchCache:
     title many users watched is searched once server-wide."""
 
     def _tmdb(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         mock_tmdb.genre_names.return_value = {}
         mock_tmdb.search.side_effect = lambda title, mt, year=None: None  # resolution isn't what we're testing
         return mock_tmdb
@@ -641,7 +666,7 @@ class TestGatherStats:
     """
 
     def test_native_web_tokens_are_recorded(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         mock_tmdb.genre_names.return_value = {}
         mock_tmdb.search.side_effect = lambda title, mt, year=None: {
             "id": 77,
@@ -664,7 +689,7 @@ class TestGatherStats:
         assert stats.exa_searches == 0  # the native tool doesn't use Exa
 
     def test_exa_path_counts_a_search_and_its_completion_tokens(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         mock_tmdb.genre_names.return_value = {}
         mock_tmdb.search.side_effect = lambda title, mt, year=None: {
             "id": 55,
@@ -696,7 +721,7 @@ class TestGatherStats:
         assert stats.exa_searches == 1  # the search request itself, billed per search
 
     def test_llm_library_tokens_are_recorded(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: []
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked([])
         catalog = {
             MediaType.MOVIE: [{"tmdb_id": 500, "rating_key": 1, "title": "Owned A", "year": 2020, "genres": ["Drama"]}]
         }
@@ -719,9 +744,9 @@ class TestGatherStats:
         assert stats.exa_searches == 0
 
     def test_tmdb_only_sources_record_no_ai_cost(self, mock_tmdb):
-        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
-            {"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}
-        ]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: _ranked(
+            [{"id": 1, "title": "S", "genre_ids": [], "vote_average": 7.0}]
+        )
         stats = GatherStats()
         gather_candidates(mock_tmdb, [seed(1)], sources=["tmdb_similar"], stats=stats)
         assert stats.tokens_by_source == {} and stats.exa_searches == 0
@@ -790,3 +815,138 @@ class TestSeedsComeFromTheRowsOwnLibraries:
         kept = _history_for_row(ctx, history, RowSpec(slug="movies", name_template="", size=10, library_keys=["1"]))
 
         assert [w.title for w in kept] == ["Match of the Day"]
+
+
+class TestTmdbAffinity:
+    """TMDB's ordering is the similarity signal — pooling it away is what produced the bug where a
+    medical drama's row filled with fantasy (beta.2 feedback)."""
+
+    @staticmethod
+    def _client(monkeypatch, recommendations: list[str], similar: list[str]):
+        from shortlist.engine.clients.tmdb import TmdbClient
+
+        client = TmdbClient.__new__(TmdbClient)
+        pages = {
+            "recommendations": [{"id": 100 + i, "name": t} for i, t in enumerate(recommendations)],
+            "similar": [{"id": 200 + i, "name": t} for i, t in enumerate(similar)],
+        }
+        monkeypatch.setattr(type(client), "_get", lambda self, path, **kw: {"results": pages[path.rsplit("/", 1)[-1]]})
+        return client
+
+    def test_recommendations_outrank_similar_and_the_top_outranks_the_tail(self, monkeypatch):
+        """Real shape of the reported case: /recommendations leads with medical dramas, /similar
+        trails off into Torchwood."""
+        client = self._client(
+            monkeypatch,
+            recommendations=["ER", "Chicago Med", "Grey's Anatomy", "Servant"],
+            similar=["Presidio Med", "St. Elsewhere", "MDs", "Torchwood"],
+        )
+
+        ranked = client.suggestions(250307, MediaType.SHOW)
+
+        by_title = {item.get("name"): affinity for item, affinity in ranked}
+        assert by_title["ER"] > by_title["Servant"], "position within an endpoint must count"
+        assert by_title["Presidio Med"] < by_title["ER"], "/similar is noisier than /recommendations"
+        assert by_title["Torchwood"] == min(by_title.values())
+        assert ranked[0][0].get("name") == "ER", "returned best-first"
+
+    def test_a_title_in_both_lists_keeps_its_strongest_claim(self, monkeypatch):
+        client = self._client(monkeypatch, recommendations=["Shared"], similar=["Shared"])
+        monkeypatch.setattr(type(client), "_get", lambda self, path, **kw: {"results": [{"id": 7, "name": "Shared"}]})
+
+        ranked = client.suggestions(1, MediaType.SHOW)
+
+        assert len(ranked) == 1
+        assert ranked[0][1] == 1.0, "the /recommendations claim beats the /similar one"
+
+    def test_every_affinity_stays_in_range(self, monkeypatch):
+        client = self._client(monkeypatch, recommendations=[f"R{i}" for i in range(20)], similar=[])
+
+        assert all(0 < affinity <= 1.0 for _item, affinity in client.suggestions(1, MediaType.SHOW))
+
+
+class TestGenreCoherence:
+    """Position alone doesn't separate a medical drama from a fantasy series.
+
+    TMDB tags The Pitt simply "Drama", and so is nearly everything it suggests — so genre OVERLAP
+    discriminates nothing. What separates them is the genres a candidate has that the seed does not:
+    Torchwood and The Sandman are also "Sci-Fi & Fantasy", and that is the entire difference.
+    """
+
+    DRAMA, SCIFI, MYSTERY, ACTION, REALITY = 18, 10765, 9648, 10759, 10764
+
+    def test_a_candidate_inside_the_seeds_genres_is_untouched(self):
+        # ER, Chicago Med, Grey's Anatomy — all plain "Drama", exactly like The Pitt.
+        assert genre_coherence({self.DRAMA}, [self.DRAMA]) == 1.0
+
+    def test_a_foreign_genre_costs_more_the_more_of_the_title_it_is(self):
+        servant = genre_coherence({self.DRAMA}, [self.DRAMA, self.MYSTERY])
+        torchwood = genre_coherence({self.DRAMA}, [self.SCIFI, self.ACTION, self.DRAMA])
+
+        assert servant > torchwood, "one foreign genre in two beats two in three"
+        assert 0.5 <= torchwood < 1.0
+
+    def test_it_never_drops_below_half(self):
+        """It shades the ranking; it must not be able to veto a title on its own."""
+        assert genre_coherence({self.DRAMA}, [self.SCIFI, self.REALITY]) == 0.5
+
+    def test_no_genres_on_either_side_means_no_opinion(self):
+        assert genre_coherence(set(), [self.DRAMA]) == 1.0
+        assert genre_coherence({self.DRAMA}, []) == 1.0
+
+    def test_the_reported_row_is_separated_from_the_medical_dramas(self):
+        """The whole point, in the reporter's own numbers: the two fantasy shows must end up
+        materially below the medical dramas, not merely a hair behind."""
+        er = genre_coherence({self.DRAMA}, [self.DRAMA])
+        sandman = genre_coherence({self.DRAMA}, [self.SCIFI, self.DRAMA, self.ACTION])
+
+        assert er - sandman >= 0.3
+
+
+class TestAffinityAcrossSources:
+    """The cell that was wrong: a title found by BOTH a ranked and an unranked source.
+
+    `Candidate.affinity` defaults to 1.0 meaning "no ranking information" — which is
+    indistinguishable from a source claiming a perfect match. So a tail suggestion that
+    `tmdb_discover` (sorted by popularity, i.e. exactly the well-known-but-unrelated titles) also
+    returned had its measured position overwritten and sailed back to the top of the row, undoing
+    the fix entirely for anyone who turned that source on.
+    """
+
+    TAIL_ID = 900
+
+    def _gather(self, mock_tmdb, sources: list[str]):
+        # One TMDB suggestion, deliberately at the bottom of /similar; discover returns the same id.
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
+            ({"id": self.TAIL_ID, "title": "The Sandman", "genre_ids": [], "vote_average": 7.9}, 0.22)
+        ]
+        mock_tmdb.discover.side_effect = lambda mt, gids, **kw: [
+            {"id": self.TAIL_ID, "title": "The Sandman", "genre_ids": [], "vote_average": 7.9}
+        ]
+        mock_tmdb.genre_ids_for.return_value = [18]
+        pool = gather_candidates(mock_tmdb, [seed(1)], sources=sources)
+        return next(c for c in pool if c.tmdb_id == self.TAIL_ID)
+
+    def test_a_measured_position_survives_an_unranked_source_finding_it_too(self, mock_tmdb):
+        ranked_only = self._gather(mock_tmdb, ["tmdb_similar"])
+        both = self._gather(mock_tmdb, ["tmdb_similar", "tmdb_discover"])
+
+        assert ranked_only.affinity == pytest.approx(0.22)
+        assert both.affinity == pytest.approx(0.22), "an unranked source must not restore the neutral 1.0"
+        assert both.sources == {"tmdb_similar", "tmdb_discover"}, "it still competes in both shares"
+
+    def test_an_unranked_source_alone_stays_neutral(self, mock_tmdb):
+        """discover has no list position to offer, so it must not be penalised for lacking one."""
+        discover_only = self._gather(mock_tmdb, ["tmdb_discover"])
+
+        assert discover_only.affinity == 1.0
+
+    def test_two_seeds_keep_the_strongest_claim(self, mock_tmdb):
+        mock_tmdb.genre_ids_for.return_value = [18]
+        mock_tmdb.suggestions.side_effect = lambda tid, mt: [
+            ({"id": self.TAIL_ID, "title": "T", "genre_ids": [], "vote_average": 7.0}, 0.3 if tid == 1 else 0.9)
+        ]
+
+        pool = gather_candidates(mock_tmdb, [seed(1), seed(2)], sources=["tmdb_similar"])
+
+        assert next(c for c in pool if c.tmdb_id == self.TAIL_ID).affinity == pytest.approx(0.9)

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -178,7 +178,15 @@ class TestTmdbClient:
             return_value=httpx.Response(200, json={"results": [{"id": 20}, {"id": 30}]})
         )
         pooled = TmdbClient("k").suggestions(1, MediaType.MOVIE)
-        assert sorted(x["id"] for x in pooled) == [10, 20, 30]
+        assert sorted(item["id"] for item, _affinity in pooled) == [10, 20, 30]
+        affinities = {item["id"]: affinity for item, affinity in pooled}
+        assert affinities[10] > affinities[30], "/recommendations vouches harder than /similar"
+        # id 20 is second in /recommendations and FIRST in /similar. With lists this short the
+        # /similar claim (0.6, top of its list) actually beats the /recommendations one (0.5,
+        # bottom of its list) — and taking the max is the point: a title keeps the best case made
+        # for it, whichever endpoint made it.
+        assert affinities[20] == 0.6
+        assert affinities[10] == 1.0 and affinities[30] == pytest.approx(0.3)
 
     @respx.mock
     def test_discover_queries_genres_and_returns_results(self):

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -15,6 +15,12 @@ from shortlist.engine.pipeline import EngineContext
 from tests.conftest import MemorySnapshotStore, fake_media_item, make_profile, make_watched, plextv_user
 
 
+def _ranked(items: list[dict], affinity: float = 1.0) -> list[tuple[dict, float]]:
+    """`TmdbClient.suggestions` returns (item, affinity) pairs. These tests predate affinity and
+    don't exercise it, so everything sits at the neutral top-of-list 1.0."""
+    return [(item, affinity) for item in items]
+
+
 @pytest.fixture
 def ctx(engine_config: EngineConfig, mock_plextv, mock_tmdb, mock_curator) -> EngineContext:
     plex = MagicMock()
@@ -34,9 +40,11 @@ def ctx(engine_config: EngineConfig, mock_plextv, mock_tmdb, mock_curator) -> En
     history = MagicMock()
     history.fetch.return_value = [make_watched("Fargo", days_ago=i, rating_key=999) for i in range(1, 5)]
 
+    # (item, affinity) pairs — see TmdbClient.suggestions. These predate affinity and don't
+    # exercise it, so both sit at the neutral top-of-list 1.0.
     mock_tmdb.suggestions.return_value = [
-        {"id": 10, "title": "Candidate Ten", "genre_ids": [], "vote_average": 8.0},
-        {"id": 20, "title": "Candidate Twenty", "genre_ids": [], "vote_average": 7.0},
+        ({"id": 10, "title": "Candidate Ten", "genre_ids": [], "vote_average": 8.0}, 1.0),
+        ({"id": 20, "title": "Candidate Twenty", "genre_ids": [], "vote_average": 7.0}, 1.0),
     ]
     mock_tmdb.genre_names.return_value = {}
 
@@ -339,7 +347,7 @@ class TestRun:
     def test_no_picks_leaves_existing_row_untouched(self, ctx: EngineContext, mock_plextv):
         sarah = make_profile("sarah", account_id=100)
         mock_plextv.users = [plextv_user(100, "sarah")]
-        ctx.tmdb.suggestions.return_value = []  # nothing suggested -> no candidates
+        ctx.tmdb.suggestions.return_value = _ranked([])  # nothing suggested -> no candidates
         ctx.curator.curate.side_effect = curated_picks
 
         report = pipeline_mod.run(ctx, [sarah])
@@ -581,10 +589,12 @@ class TestPerRowOverrides:
 
         # 59 high-rated movies flood the pool and ONE lower-rated show — from the SAME source, so a
         # source quota can't rescue it. Only filtering by media BEFORE the cut can.
-        def suggestions(tid, mt):
+        def suggestions(tid, mt):  # returns (item, affinity) pairs
             if mt is MediaType.MOVIE:
-                return [{"id": i, "title": f"Movie {i}", "genre_ids": [], "vote_average": 9.0} for i in range(1, 60)]
-            return [{"id": 5001, "title": "A Show", "genre_ids": [], "vote_average": 6.0}]
+                return _ranked(
+                    [{"id": i, "title": f"Movie {i}", "genre_ids": [], "vote_average": 9.0} for i in range(1, 60)]
+                )
+            return _ranked([{"id": 5001, "title": "A Show", "genre_ids": [], "vote_average": 6.0}])
 
         ctx.tmdb.suggestions.side_effect = suggestions
         ctx.config.candidate_sources = ["tmdb_similar"]
@@ -700,12 +710,12 @@ class TestPerRowOverrides:
         shows = {5000: 5999, **{5000 + i: 6000 + i for i in range(1, 40)}}
         ctx.plex.build_library_index.side_effect = lambda sec, ep=None: (movies if sec is movie_section else shows, {})
 
-        def suggestions(tid, mt):
+        def suggestions(tid, mt):  # returns (item, affinity) pairs
             # Plenty of BOTH movie and show candidates in the pool.
             base = 1 if mt is MediaType.MOVIE else 5000
-            return [
-                {"id": base + i, "title": f"T{base + i}", "genre_ids": [], "vote_average": 8.0} for i in range(1, 40)
-            ]
+            return _ranked(
+                [{"id": base + i, "title": f"T{base + i}", "genre_ids": [], "vote_average": 8.0} for i in range(1, 40)]
+            )
 
         ctx.tmdb.suggestions.side_effect = suggestions
         # A watcher of one movie + one show, so both media types seed.
@@ -744,7 +754,7 @@ class TestPerRowOverrides:
         pool = [
             {"id": i, "title": f"T{i}", "genre_ids": [], "vote_average": 8.0} for i in [*range(10, 16), *range(50, 56)]
         ]
-        ctx.tmdb.suggestions.side_effect = lambda tid, mt: pool
+        ctx.tmdb.suggestions.side_effect = lambda tid, mt: _ranked(pool)
         ctx.history_source.fetch.return_value = [make_watched("Fargo", days_ago=1, rating_key=999)]
         ctx.config.rows = [RowSpec(slug="picked", name_template="", size=5, media="movie")]
         ctx.config.min_history = 1
@@ -773,7 +783,7 @@ class TestPerRowOverrides:
         pool = [
             {"id": i, "title": f"T{i}", "genre_ids": [], "vote_average": 8.0} for i in [*range(10, 16), *range(50, 56)]
         ]
-        ctx.tmdb.suggestions.side_effect = lambda tid, mt: pool
+        ctx.tmdb.suggestions.side_effect = lambda tid, mt: _ranked(pool)
         ctx.history_source.fetch.return_value = [make_watched("Fargo", days_ago=1, rating_key=999)]
         ctx.config.rows = [RowSpec(slug="picked", name_template="", size=5, media="movie")]
         ctx.config.min_history = 1
@@ -800,7 +810,7 @@ class TestPerRowOverrides:
         idx = {900: 999, **{i: 1000 + i for i in range(10, 20)}}
         ctx.plex.build_library_index.return_value = (idx, {})
         pool = [{"id": i, "title": f"T{i}", "genre_ids": [], "vote_average": 8.0} for i in range(10, 20)]
-        ctx.tmdb.suggestions.side_effect = lambda tid, mt: pool
+        ctx.tmdb.suggestions.side_effect = lambda tid, mt: _ranked(pool)
         ctx.history_source.fetch.return_value = [make_watched("Fargo", days_ago=1, rating_key=999)]
         ctx.config.rows = [RowSpec(slug="picked", name_template="", size=5, media="movie", freshness=freshness)]
         ctx.config.min_history = 1
@@ -895,10 +905,12 @@ class TestPerRowOverrides:
         AI cost. Default sources are TMDB-only, so every token here is curation (no gather/Exa)."""
         sarah = make_profile("sarah", account_id=100)
         mock_plextv.users = [plextv_user(100, "sarah")]
-        ctx.tmdb.suggestions.return_value = [
-            {"id": 10, "title": "Fresh Ten", "genre_ids": [], "vote_average": 8.0},
-            {"id": 20, "title": "Fresh Twenty", "genre_ids": [], "vote_average": 7.0},
-        ]
+        ctx.tmdb.suggestions.return_value = _ranked(
+            [
+                {"id": 10, "title": "Fresh Ten", "genre_ids": [], "vote_average": 8.0},
+                {"id": 20, "title": "Fresh Twenty", "genre_ids": [], "vote_average": 7.0},
+            ]
+        )
         ctx.plex.build_library_index.return_value = ({900: 999, 10: 1010, 20: 1020}, {})
         ctx.curator.curate.side_effect = curated_picks
         ctx.curator.last_tokens = 50  # each curated (row, library) section reports this
@@ -980,11 +992,13 @@ class TestPerRowOverrides:
         sarah = make_profile("sarah", account_id=100)
         mock_plextv.users = [plextv_user(100, "sarah")]
         # She finished movie 900 (the seed, ratingKey 999). It resurfaces as a candidate — must drop.
-        ctx.tmdb.suggestions.return_value = [
-            {"id": 900, "title": "Already Finished", "genre_ids": [], "vote_average": 9.0},
-            {"id": 10, "title": "Fresh Ten", "genre_ids": [], "vote_average": 8.0},
-            {"id": 20, "title": "Fresh Twenty", "genre_ids": [], "vote_average": 7.0},
-        ]
+        ctx.tmdb.suggestions.return_value = _ranked(
+            [
+                {"id": 900, "title": "Already Finished", "genre_ids": [], "vote_average": 9.0},
+                {"id": 10, "title": "Fresh Ten", "genre_ids": [], "vote_average": 8.0},
+                {"id": 20, "title": "Fresh Twenty", "genre_ids": [], "vote_average": 7.0},
+            ]
+        )
         ctx.plex.build_library_index.return_value = ({900: 999, 10: 1010, 20: 1020}, {})
         ctx.curator.curate.side_effect = curated_picks
 
@@ -1007,10 +1021,12 @@ class TestPerRowOverrides:
             make_watched("Seed Movie", days_ago=1, rating_key=999),  # tmdb 900 — the sole seed
             make_watched("Finished Extra", days_ago=9, rating_key=550),  # tmdb 50 — finished, not a seed
         ]
-        ctx.tmdb.suggestions.return_value = [
-            {"id": 50, "title": "Finished Extra", "genre_ids": [], "vote_average": 9.0},  # finished, resurfaced
-            {"id": 10, "title": "Fresh Ten", "genre_ids": [], "vote_average": 8.0},
-        ]
+        ctx.tmdb.suggestions.return_value = _ranked(
+            [
+                {"id": 50, "title": "Finished Extra", "genre_ids": [], "vote_average": 9.0},  # finished, resurfaced
+                {"id": 10, "title": "Fresh Ten", "genre_ids": [], "vote_average": 8.0},
+            ]
+        )
         ctx.plex.build_library_index.return_value = ({900: 999, 50: 550, 10: 1010}, {})
         ctx.curator.curate.side_effect = curated_picks
 
@@ -1073,10 +1089,12 @@ class TestRequestsWiring:
 
     def _suggest_a_missing_title(self, ctx: EngineContext) -> None:
         # Candidate 30 is NOT in the library index (which holds only 10 and 20), so it's requestable.
-        ctx.tmdb.suggestions.return_value = [
-            {"id": 10, "title": "In Library", "genre_ids": [], "vote_average": 8.0, "vote_count": 900},
-            {"id": 30, "title": "Missing Title", "genre_ids": [], "vote_average": 8.4, "vote_count": 800},
-        ]
+        ctx.tmdb.suggestions.return_value = _ranked(
+            [
+                {"id": 10, "title": "In Library", "genre_ids": [], "vote_average": 8.0, "vote_count": 900},
+                {"id": 30, "title": "Missing Title", "genre_ids": [], "vote_average": 8.4, "vote_count": 800},
+            ]
+        )
 
     def test_disabled_by_default_never_calls_the_request_pass(self, ctx: EngineContext, mock_plextv, monkeypatch):
         sarah = make_profile("sarah", account_id=100)
@@ -1364,9 +1382,11 @@ class TestPlacement:
         idx_4k = {900: 999, 800: 888, **{i: 2000 + i for i in range(50, 56)}}
         ctx.plex.build_library_index.side_effect = lambda sec, ep=None: (idx_std if sec is movies else idx_4k, {})
 
-        def suggestions(tid, mt):
+        def suggestions(tid, mt):  # returns (item, affinity) pairs
             base = 10 if tid == 900 else 50  # Fargo -> Movies ids, Heat -> 4K ids
-            return [{"id": base + i, "title": f"T{base + i}", "genre_ids": [], "vote_average": 8.0} for i in range(6)]
+            return _ranked(
+                [{"id": base + i, "title": f"T{base + i}", "genre_ids": [], "vote_average": 8.0} for i in range(6)]
+            )
 
         ctx.tmdb.suggestions.side_effect = suggestions
         ctx.history_source.fetch.return_value = [

--- a/tests/unit/test_privacy.py
+++ b/tests/unit/test_privacy.py
@@ -16,6 +16,7 @@ from shortlist.engine.privacy import (
     remove_label_excludes,
     serialize_filter,
     shortlist_labels_in,
+    summarise_filter_diff,
     sync_user_restrictions,
 )
 from tests.conftest import make_profile, plextv_user
@@ -436,3 +437,59 @@ class TestRestore:
         mock_plextv.update_user_filters.side_effect = lambda account_id, fields: None
         with pytest.raises(RuntimeError, match="restore mismatch"):
             privacy.restore_user_restrictions(mock_plextv, snapshot)
+
+
+class TestFilterDiffSummary:
+    """A 48-user server puts every other account's exclude in each account's filter string, so
+    logging the before AND after was ~8 KB per user per field — the same 47 labels every time, with
+    the one that changed buried in the middle. The full diff still goes to the audit event."""
+
+    PREFIX = "Shortlist"
+
+    def _long_filter(self, n: int, extra: str = "") -> str:
+        labels = [f"{self.PREFIX}_user{i}" for i in range(n)]
+        if extra:
+            labels.append(extra)
+        return "label!=" + ",".join(labels)
+
+    def test_it_names_only_what_changed(self):
+        before, after = self._long_filter(47), self._long_filter(47, f"{self.PREFIX}_s_flix")
+
+        summary = summarise_filter_diff({"filterMovies": (before, after)}, self.PREFIX)
+
+        assert summary == "filterMovies +1 (Shortlist_s_flix)"
+        assert "user0" not in summary, "the 47 unchanged labels are noise"
+        assert len(summary) < 100, f"a log line, not a dump: {len(summary)} chars"
+
+    def test_a_first_run_adding_everyone_stays_short(self):
+        summary = summarise_filter_diff({"filterMovies": ("", self._long_filter(47))}, self.PREFIX)
+
+        assert "+47" in summary
+        assert "+44 more" in summary, "list a few, count the rest"
+        assert len(summary) < 120
+
+    def test_removals_are_reported_too(self):
+        before, after = self._long_filter(3), self._long_filter(2)
+
+        assert summarise_filter_diff({"filterMovies": (before, after)}, self.PREFIX) == (
+            "filterMovies -1 (Shortlist_user2)"
+        )
+
+    def test_both_fields_are_covered(self):
+        before, after = self._long_filter(1), self._long_filter(2)
+
+        summary = summarise_filter_diff(
+            {"filterMovies": (before, after), "filterTelevision": (before, after)}, self.PREFIX
+        )
+
+        assert summary.count("Shortlist_user1") == 2
+        assert "filterMovies" in summary and "filterTelevision" in summary
+
+    def test_a_change_outside_our_labels_is_still_reported(self):
+        """Pruning a shared row's label can leave our own exclude set identical — the write still
+        happened, so the log must not claim nothing changed."""
+        summary = summarise_filter_diff(
+            {"filterMovies": ("label!=Shortlist_a,other", "label!=Shortlist_a")}, self.PREFIX
+        )
+
+        assert summary == "filterMovies rewritten"

--- a/tests/unit/test_ranking.py
+++ b/tests/unit/test_ranking.py
@@ -1,4 +1,8 @@
-from shortlist.engine.models import MediaType, Seed
+from types import SimpleNamespace
+
+from loguru import logger
+
+from shortlist.engine.models import Candidate, MediaType, Pick, RowSpec, Seed, UserProfile, UserType
 from shortlist.engine.ranking import pre_rank, score
 from tests.conftest import make_candidate
 
@@ -260,3 +264,164 @@ class TestFreshnessCadence:
             next(d for d in range(1, period + 1) if _is_refresh_night(f"row{n}", f"user{n}", d, 0.5)) for n in range(8)
         }
         assert len(phases) > 1
+
+
+class TestAffinityBeatsRating:
+    """The Pitt bug (beta.2 feedback): a medical drama's row filled with The Sandman, Servant,
+    Torchwood and King & Conqueror — all genuinely in TMDB's lists for it, all near the bottom.
+
+    TMDB's own ordering was the similarity signal and it was being discarded, leaving the average
+    vote as the only tiebreak. The fix is only real if a WORSE-RATED, closer title now wins.
+    """
+
+    @staticmethod
+    def _candidate(title: str, rating: float, affinity: float) -> Candidate:
+        return Candidate(
+            tmdb_id=abs(hash(title)) % 100000,
+            title=title,
+            media_type=MediaType.SHOW,
+            rating=rating,
+            affinity=affinity,
+            sources={"tmdb_similar"},
+            seeds=[Seed(tmdb_id=250307, title="The Pitt", media_type=MediaType.SHOW, weight=1.0)],
+        )
+
+    def test_a_close_match_outranks_a_better_rated_distant_one(self):
+        # Real numbers: ER is TMDB's #1 recommendation for The Pitt; Torchwood is partway down
+        # /similar, and rates higher than several of the medical dramas above it.
+        er = self._candidate("ER", rating=7.8, affinity=1.0)
+        torchwood = self._candidate("Torchwood", rating=7.3, affinity=0.43)
+        sandman = self._candidate("The Sandman", rating=7.8, affinity=0.40)
+
+        assert score(er) > score(torchwood)
+        assert score(er) > score(sandman)
+        assert [c.title for c in pre_rank([sandman, torchwood, er], keep=2)] == ["ER", "Torchwood"]
+
+    def test_rating_alone_no_longer_decides(self):
+        """The exact inversion that produced the bug: same seed, one better rated but far less
+        similar. Before affinity, the higher rating simply won."""
+        close = self._candidate("Chicago Med", rating=8.3, affinity=1.0)
+        distant = self._candidate("Traitors", rating=9.0, affinity=0.32)
+
+        assert score(close) > score(distant), "a 9.0 from the tail must not beat an 8.3 from the top"
+
+    def test_a_source_with_no_ranking_is_not_penalised(self):
+        """discover / Trakt / the LLM sources have no list position to offer. Defaulting them to 0
+        would zero them out — the same mistake the multiplicative seed weight made originally."""
+        llm_pick = Candidate(tmdb_id=1, title="AI pick", media_type=MediaType.SHOW, rating=7.0, sources={"llm_library"})
+
+        assert llm_pick.affinity == 1.0
+        assert score(llm_pick) > 0
+
+
+class TestPaddingFloor:
+    """A row is allowed to come up short. Filling it from the tail is how "Because you watched The
+    Pitt" ended up over four titles that had nothing to do with it."""
+
+    @staticmethod
+    def _pool(affinities: list[float]) -> list[Candidate]:
+        return [
+            Candidate(
+                tmdb_id=i,
+                title=f"T{i}",
+                media_type=MediaType.SHOW,
+                rating=8.0,
+                affinity=a,
+                sources={"tmdb_similar"},
+                rating_key=1000 + i,
+                seeds=[Seed(tmdb_id=250307, title="The Pitt", media_type=MediaType.SHOW, weight=1.0)],
+            )
+            for i, a in enumerate(affinities)
+        ]
+
+    def test_a_short_row_beats_a_padded_one(self):
+        from shortlist.engine.rows import _pad_picks
+
+        padded = _pad_picks([], self._pool([0.9, 0.8, 0.2, 0.1]), k=4)
+
+        assert [p.title for p in padded] == ["T0", "T1"], "the tail must not be delivered"
+
+    def test_a_source_without_a_ranking_is_still_allowed_to_fill(self):
+        """discover / Trakt / LLM picks sit at the neutral 1.0 — they are deliberate, not tail."""
+        from shortlist.engine.rows import _pad_picks
+
+        pool = self._pool([1.0, 1.0])
+        for c in pool:
+            c.sources = {"llm_library"}
+
+        assert len(_pad_picks([], pool, k=2)) == 2
+
+
+class TestRowProvenanceLogging:
+    """The log has to answer "why is this here?" on its own — the reported case was diagnosed by
+    querying TMDB by hand because nothing in the log said where a pick came from."""
+
+    @staticmethod
+    def _picks() -> list[Pick]:
+        return [
+            Pick(
+                tmdb_id=1,
+                rating_key=10,
+                title="Chicago Med",
+                rank=1,
+                reason="Because you watched The Pitt",
+                media_type=MediaType.SHOW,
+                seed_title="The Pitt",
+                sources=["tmdb_similar"],
+                affinity=0.92,
+            )
+        ]
+
+    @staticmethod
+    def _captured(fn, level="DEBUG") -> str:
+        """loguru does not route through stdlib logging, so `caplog` sees nothing — capture with a
+        real sink, exactly as the file sink the Logs view reads would."""
+        lines: list[str] = []
+        sink_id = logger.add(lines.append, level=level, format="{message}")
+        try:
+            fn()
+        finally:
+            logger.remove(sink_id)
+        return "".join(lines)
+
+    def test_it_records_the_seed_source_and_strength_of_every_pick(self):
+        from shortlist.engine.rows import _log_row_provenance
+
+        logged = self._captured(
+            lambda: _log_row_provenance(
+                UserProfile(username="sarah", plex_account_id=1, user_type=UserType.SHARED),
+                RowSpec(slug="picked", name_template="", size=1),
+                SimpleNamespace(title="TV Shows"),
+                self._picks(),
+                [],
+                1,
+            )
+        )
+        assert "Chicago Med" in logged
+        assert "The Pitt" in logged, "the seed must be in the log, not just the UI"
+        assert "tmdb_similar" in logged, "which source suggested it"
+        assert "0.92" in logged, "how strong the claim was"
+
+    def test_a_short_row_says_why_it_is_short(self):
+        """A deliberately-short row must not read as a failure."""
+        from shortlist.engine.rows import _log_row_provenance
+
+        pool = [
+            Candidate(tmdb_id=9, title="Torchwood", media_type=MediaType.SHOW, affinity=0.28),
+            Candidate(tmdb_id=8, title="The Sandman", media_type=MediaType.SHOW, affinity=0.26),
+        ]
+
+        logged = self._captured(
+            lambda: _log_row_provenance(
+                UserProfile(username="sarah", plex_account_id=1, user_type=UserType.SHARED),
+                RowSpec(slug="picked", name_template="", size=5),
+                SimpleNamespace(title="TV Shows"),
+                self._picks(),
+                pool,
+                5,
+            ),
+            level="INFO",
+        )
+
+        assert "too loosely related" in logged
+        assert "Torchwood" in logged, "naming the closest rejection makes the cut auditable"

--- a/tests/unit/test_run_service_context.py
+++ b/tests/unit/test_run_service_context.py
@@ -171,6 +171,8 @@ class TestBuildContext:
                     section_key=section,
                     title=f"t{tmdb_id}",
                     reason="because",
+                    sources="tmdb_similar",
+                    affinity=0.42,
                 )
 
             # An older run's picks for the row, then a newer run that rebuilt it — carry-forward must
@@ -187,6 +189,11 @@ class TestBuildContext:
         assert got[0].title == "t201" and got[0].reason == "because"
         # The legacy unstamped pick maps to no row and is dropped, not filed under ("", "").
         assert ("sarah", "", "") not in ctx.previous_picks
+        # Provenance round-trips. Without this a carried-forward pick comes back blank, so on every
+        # non-refresh night the UI's "suggested by …" line vanishes and the pick is RE-PERSISTED as
+        # "not recorded" — provenance would survive exactly one run.
+        assert got[0].sources == ["tmdb_similar"]
+        assert got[0].affinity == 0.42
 
 
 class TestBuildRequests:

--- a/web/src/components/pick-list.tsx
+++ b/web/src/components/pick-list.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { provenanceLabel } from "@/lib/pick-provenance";
 import type { Pick } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -42,6 +43,13 @@ export function PickList({
                 — {pick.reason}
                 {pick.seed_title ? ` · inspired by ${pick.seed_title}` : ""}
               </span>
+              {/* Where it came from, on its own line: "why is this here?" was previously
+                  unanswerable without reading the logs. */}
+              {provenanceLabel(pick) ? (
+                <span className="block text-xs text-muted-foreground/80">
+                  {provenanceLabel(pick)}
+                </span>
+              ) : null}
             </span>
           </li>
         ))}

--- a/web/src/lib/pick-provenance.ts
+++ b/web/src/lib/pick-provenance.ts
@@ -1,0 +1,56 @@
+import type { Pick } from "@/lib/types";
+
+/** What each candidate source is called in the UI. Ids come from the engine's `candidate_sources`. */
+const SOURCE_LABELS: Record<string, string> = {
+  tmdb_similar: "TMDB",
+  tmdb_discover: "TMDB (your genres)",
+  trakt: "Trakt",
+  llm_library: "AI, from your library",
+  llm_web: "AI web search",
+  cold_start: "Popular on this server",
+  tmdb_both: "TMDB (similar + your genres)",
+};
+
+/**
+ * How confident the suggestion was. `affinity` is 0..1: how near the top of the suggesting source's
+ * list the title sat, so 1.0 means "the closest match it had" and 0.4 means "it was mentioned".
+ *
+ * Sources with no ranking of their own (Trakt, the AI sources) always report 1.0 — that is "no
+ * ranking information", not "perfect match", which is why nothing here claims a strength for them.
+ */
+export type MatchStrength = "close" | "related" | "loose";
+
+export function matchStrength(affinity: number): MatchStrength {
+  if (affinity >= 0.8) return "close";
+  if (affinity >= 0.5) return "related";
+  return "loose";
+}
+
+export const STRENGTH_LABELS: Record<MatchStrength, string> = {
+  close: "close match",
+  related: "related",
+  loose: "loosely related",
+};
+
+export function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source;
+}
+
+/**
+ * The one-line provenance for a pick: which source suggested it, and — for ranked sources — how
+ * strongly. Empty when the pick predates provenance being recorded (pre-0035 rows), so the UI can
+ * say nothing rather than imply a match it never measured.
+ */
+export function provenanceLabel(pick: Pick): string {
+  const sources = pick.sources ?? [];
+  if (sources.length === 0) return "";
+  // Both TMDB sources on one pick would read "TMDB (your genres) + TMDB", which looks like a bug.
+  const both = sources.includes("tmdb_similar") && sources.includes("tmdb_discover");
+  const shown = both ? ["tmdb_both", ...sources.filter((s) => !s.startsWith("tmdb_"))] : sources;
+  const names = shown.map(sourceLabel).join(" + ");
+  // ONLY tmdb_similar ranks its suggestions. tmdb_discover is "popular in genres you like" — it is
+  // permanently 1.0, so matching it here would stamp "close match" on every discover pick forever.
+  const ranked = sources.includes("tmdb_similar");
+  if (!ranked || pick.affinity === undefined) return `suggested by ${names}`;
+  return `suggested by ${names} · ${STRENGTH_LABELS[matchStrength(pick.affinity)]}`;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -261,6 +261,10 @@ export interface Pick {
   reason: string;
   /** Which watched title produced this pick, when the pipeline knows it. */
   seed_title?: string;
+  /** Candidate source ids that surfaced this pick; empty on picks written before provenance existed. */
+  sources?: string[];
+  /** 0..1, how near the top of the suggesting source's list it sat. 1.0 also means "unranked source". */
+  affinity?: number;
   media_type?: string;
   /** Which row this pick belongs to (Collection slug). */
   collection_slug?: string;

--- a/web/src/test/pick-provenance.test.ts
+++ b/web/src/test/pick-provenance.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { matchStrength, provenanceLabel } from "@/lib/pick-provenance";
+import type { Pick } from "@/lib/types";
+
+function pick(over: Partial<Pick> = {}): Pick {
+  return {
+    rank: 1,
+    title: "The Sandman",
+    reason: "Because you watched The Pitt",
+    ...over,
+  } as Pick;
+}
+
+describe("provenanceLabel", () => {
+  it("names the source and how strong the match was", () => {
+    expect(provenanceLabel(pick({ sources: ["tmdb_similar"], affinity: 1.0 }))).toBe(
+      "suggested by TMDB · close match",
+    );
+  });
+
+  it("admits when a pick was only loosely related", () => {
+    // The reported bug: The Sandman sat near the bottom of TMDB's list for a medical drama and was
+    // presented exactly like a top match. Now it says so.
+    expect(provenanceLabel(pick({ sources: ["tmdb_similar"], affinity: 0.4 }))).toBe(
+      "suggested by TMDB · loosely related",
+    );
+  });
+
+  it("claims no strength for a source that does not rank its suggestions", () => {
+    // Trakt and the AI sources report the neutral 1.0 because they have no list position to give —
+    // rendering that as "close match" would be inventing a measurement.
+    expect(provenanceLabel(pick({ sources: ["llm_web"], affinity: 1.0 }))).toBe(
+      "suggested by AI web search",
+    );
+    expect(provenanceLabel(pick({ sources: ["trakt"], affinity: 1.0 }))).toBe("suggested by Trakt");
+  });
+
+  it("claims no strength for tmdb_discover, which never measured one", () => {
+    // "popular in genres you like" is permanently 1.0 — matching on the `tmdb_` prefix stamped
+    // "close match" on every discover pick forever.
+    expect(provenanceLabel(pick({ sources: ["tmdb_discover"], affinity: 1.0 }))).toBe(
+      "suggested by TMDB (your genres)",
+    );
+    expect(provenanceLabel(pick({ sources: ["cold_start"], affinity: 1.0 }))).toBe(
+      "suggested by Popular on this server",
+    );
+  });
+
+  it("reads sensibly when both TMDB sources found it", () => {
+    expect(provenanceLabel(pick({ sources: ["tmdb_discover", "tmdb_similar"], affinity: 0.9 }))).toBe(
+      "suggested by TMDB (similar + your genres) · close match",
+    );
+  });
+
+  it("lists every source when more than one found it", () => {
+    expect(provenanceLabel(pick({ sources: ["llm_library", "trakt"] }))).toBe(
+      "suggested by AI, from your library + Trakt",
+    );
+  });
+
+  it("says nothing for picks made before provenance was recorded", () => {
+    expect(provenanceLabel(pick())).toBe("");
+    expect(provenanceLabel(pick({ sources: [] }))).toBe("");
+  });
+});
+
+describe("matchStrength", () => {
+  it("splits the range at the boundaries the copy promises", () => {
+    expect(matchStrength(1.0)).toBe("close");
+    expect(matchStrength(0.8)).toBe("close");
+    expect(matchStrength(0.79)).toBe("related");
+    expect(matchStrength(0.5)).toBe("related");
+    expect(matchStrength(0.49)).toBe("loose");
+  });
+});


### PR DESCRIPTION
Promotes `dev` to `master` for the third public beta.

## Picks that actually resemble what you watched

A beta user's row seeded by **The Pitt** — a medical drama — came back as The Sandman, Servant,
Torchwood and King & Conqueror. TMDB wasn't at fault: its recommendations for that show are ER,
Chicago Med, Grey's Anatomy, Code Black. Shortlist was reading the right list and picking from the
wrong end of it.

- **TMDB's ordering is no longer discarded.** Suggestions were pooled into one bag, so "#1 closest
  match" and "#19, loosely related" arrived indistinguishable — and `/similar` was weighted the same
  as `/recommendations`.
- **Ranking now asks whether a title is similar, not just well-rated.** With position gone, TMDB's
  average vote was the only discriminator — which on real data put *Traitors*, a reality competition
  show, at the top of a medical drama's row.
- **Genre coherence.** TMDB tags The Pitt simply "Drama", as it does nearly everything it suggests —
  but Torchwood and The Sandman are *also* "Sci-Fi & Fantasy".

Verified against the live TMDB response, not a fixture:

```
before: Traitors, The Good Doctor, New Amsterdam, Queer as Folk, Big White Duel
after:  Chicago Med, ER, Grey's Anatomy, Code Black, Transplant
```

**Rows may now come up short**, and that's the point — four titles that fit beat ten where six are
filler. The run log says so, naming the closest rejected title.

## Where every pick came from

Each pick records its source and how strongly that source vouched (migration 0035), shown under the
title as *"suggested by TMDB · loosely related"*, and printed per row at DEBUG with seed, source and
affinity. Nothing claims a strength it didn't measure.

## Build and logs

- Docker dependency layer no longer invalidated by every source change (a source-only rebuild is now
  `CACHED`); the web stage builds natively instead of under arm64 QEMU.
- `filters merged` logged ~8 KB per user per field on a 48-user server. It now reports the delta;
  the full diff still goes to the audit event.
- Release tags publish `:dev` alongside `:latest` and the version tag.

Full detail in CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)