### PR TITLE
release: v0.1.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. This project follows
 [Conventional Commits](https://www.conventionalcommits.org/) and
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.0-beta.4] - 2026-07-22
+
+### Fixed
+
+- **The run page now shows where each pick came from.** beta.3 added the "suggested by TMDB ·
+  loosely related" line, but the run detail page renders its picks with its own component — so the
+  line appeared on the user page and nowhere else, including the one screen people open to ask
+  exactly that question.
+
+Picks kept from an earlier run still show nothing, which is correct: those were written before
+provenance was recorded, so it genuinely isn't known. They gain it the first time they are rebuilt.
+
 ## [0.1.0-beta.3] - 2026-07-22
 
 Picks that actually resemble what you watched.

--- a/shortlist/__init__.py
+++ b/shortlist/__init__.py
@@ -1,3 +1,3 @@
 """Shortlist — a private, AI-curated "Picked for You" row for every user on your Plex server."""
 
-__version__ = "0.1.0b3"
+__version__ = "0.1.0b4"

--- a/web/src/pages/run-detail.tsx
+++ b/web/src/pages/run-detail.tsx
@@ -19,6 +19,7 @@ import { Link, useParams } from "react-router-dom";
 
 import { BackLink } from "@/components/back-link";
 import { PickList } from "@/components/pick-list";
+import { provenanceLabel } from "@/lib/pick-provenance";
 import { QueryBoundary, EmptyState } from "@/components/query-boundary";
 import { Segmented } from "@/components/segmented";
 import { UserAvatar } from "@/components/user-avatar";
@@ -176,7 +177,8 @@ function rankClass(rank: number): string {
   return "text-muted-foreground";
 }
 
-/** One ranked pick: rank, a status dot (green = new this run), title, and its reason (one line). */
+/** One ranked pick: rank, a status dot (green = new this run), title + reason, and where it
+ *  came from. */
 function PickLine({ pick, isNew }: { pick: Pick; isNew: boolean }) {
   return (
     <li className="flex items-baseline gap-3 py-1.5">
@@ -196,10 +198,20 @@ function PickLine({ pick, isNew }: { pick: Pick; isNew: boolean }) {
         aria-label={isNew ? "new this run" : "kept"}
         title={isNew ? "New this run" : "Kept from last run"}
       />
-      <span className="min-w-0 flex-1 truncate text-sm">
-        <span className="font-medium">{pick.title}</span>
-        {pick.reason && (
-          <span className="text-muted-foreground"> — {pick.reason}</span>
+      <span className="min-w-0 flex-1 text-sm">
+        <span className="block truncate">
+          <span className="font-medium">{pick.title}</span>
+          {pick.reason && (
+            <span className="text-muted-foreground"> — {pick.reason}</span>
+          )}
+        </span>
+        {/* Where it came from. This page has its own pick renderer rather than using PickList, so
+            the provenance line has to be repeated here — it is the page people open to ask exactly
+            this question. */}
+        {provenanceLabel(pick) && (
+          <span className="block truncate text-xs text-muted-foreground/80">
+            {provenanceLabel(pick)}
+          </span>
         )}
       </span>
     </li>

--- a/web/src/test/run-detail.test.tsx
+++ b/web/src/test/run-detail.test.tsx
@@ -104,6 +104,8 @@ describe("RunDetailPage — grouped by library", () => {
               title: "Saving Private Ryan",
               reason: "war epic",
               seed_title: "Pressure",
+              sources: ["tmdb_similar"],
+              affinity: 0.42,
             },
           ],
         },
@@ -140,6 +142,11 @@ describe("RunDetailPage — grouped by library", () => {
       screen.getByRole("button", { name: /TV Shows/ }),
     ).toBeInTheDocument();
     expect(screen.getByText(/war epic/)).toBeInTheDocument();
+    // This page is where "why did it pick that?" gets asked, and it has its OWN pick renderer
+    // rather than using PickList — so the provenance line has to be asserted here separately.
+    expect(
+      screen.getByText(/suggested by TMDB · loosely related/),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/survival series/)).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: /TV Shows/ }));


### PR DESCRIPTION
Promotes `dev` to `master` for beta.4 — a follow-up fix to beta.3.

**The run page now shows where each pick came from.** beta.3 added the "suggested by TMDB · loosely
related" line, but the run detail page renders its picks with its own component rather than the
shared `PickList` — so the line appeared on the user page and nowhere else, including the one screen
people open to ask exactly that question. The feature looked shipped and wasn't.

Picks kept from an earlier run still show nothing, which is correct: those rows were written before
provenance existed, so it genuinely isn't known. They gain it the first time they're rebuilt.

The new test asserts the line renders on the run page specifically, so the shared component passing
can't mask this again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)