### PR TITLE
release: v0.1.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. This project follows
 [Conventional Commits](https://www.conventionalcommits.org/) and
 [Semantic Versioning](https://semver.org/).
 
+## [0.1.0-beta.5] - 2026-07-22
+
+### Fixed
+
+- **The run page really does show where each pick came from now.** There were three places that
+  build a pick, and the run page renders the one that was still missing provenance — a stored
+  per-(row, library) breakdown, not the picks table. beta.4 fixed the renderer; the data feeding it
+  was still blank.
+- **Existing runs explain themselves too.** Provenance is joined onto the breakdown from the picks
+  rows when a run is read, so runs recorded before this don't stay blank until they're rebuilt. A
+  pick with no matching row stays blank rather than being given an invented source.
+
 ## [0.1.0-beta.4] - 2026-07-22
 
 ### Fixed

--- a/shortlist/__init__.py
+++ b/shortlist/__init__.py
@@ -1,3 +1,3 @@
 """Shortlist — a private, AI-curated "Picked for You" row for every user on your Plex server."""
 
-__version__ = "0.1.0b4"
+__version__ = "0.1.0b5"

--- a/shortlist/engine/delivery.py
+++ b/shortlist/engine/delivery.py
@@ -365,6 +365,11 @@ def deliver_rows(
                             "seed_title": p.seed_title,
                             "tmdb_id": p.tmdb_id,
                             "media_type": p.media_type.value,
+                            # The run page renders THIS blob, not the picks table — so provenance
+                            # has to be here too, or "why was this picked?" is unanswerable on the
+                            # one screen built to answer it.
+                            "sources": list(p.sources),
+                            "affinity": p.affinity,
                         }
                         for p in this_section
                     ],

--- a/shortlist/server/api/runs.py
+++ b/shortlist/server/api/runs.py
@@ -82,6 +82,33 @@ async def clear_runs(request: Request) -> dict:
     return {"deleted": deleted}
 
 
+def _with_provenance(breakdown: list[dict], picks: list) -> list[dict]:
+    """Fill in `sources`/`affinity` on breakdown picks from the picks table.
+
+    The run page renders the stored breakdown blob, which only started carrying provenance from the
+    run that introduced it — but the `picks` rows for those same runs have it. Joining on
+    (tmdb_id, media_type) means an existing run explains itself immediately instead of staying blank
+    until it is rebuilt. Entries that already carry provenance are left alone.
+    """
+    known = {(p.tmdb_id, p.media_type): p for p in picks}
+    out = []
+    for entry in breakdown:
+        enriched = []
+        for pick in entry.get("picks") or []:
+            if pick.get("sources"):
+                enriched.append(pick)
+                continue
+            row = known.get((pick.get("tmdb_id"), pick.get("media_type")))
+            if row is None:
+                enriched.append(pick)
+                continue
+            enriched.append(
+                {**pick, "sources": [s for s in (row.sources or "").split(",") if s], "affinity": row.affinity}
+            )
+        out.append({**entry, "picks": enriched})
+    return out
+
+
 @router.get("/{run_id}")
 async def get_run(run_id: int, request: Request) -> dict:
     with request.app.state.sessions() as session:
@@ -121,7 +148,7 @@ async def get_run(run_id: int, request: Request) -> dict:
                         for p in picks
                     ],
                     # Per-(row, library) breakdown; [] on legacy runs -> UI falls back to diff + picks.
-                    "breakdown": run_user.breakdown or [],
+                    "breakdown": _with_provenance(run_user.breakdown or [], picks),
                 }
             )
         return {**_run_summary(run), "users": users}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -646,6 +646,86 @@ class TestRunsApi:
         assert result["reason"] == "There are no per-person rows to build."
         assert result["error"] is None
 
+    def test_the_run_page_gets_provenance_on_the_breakdown_it_actually_renders(self, client: TestClient):
+        """The run page renders the stored `breakdown` blob, NOT the picks list — so provenance
+        added to the picks table alone was invisible on the one screen built to answer "why was
+        this picked?". Backfilled from the picks rows so existing runs explain themselves too,
+        instead of staying blank until they are rebuilt."""
+        from shortlist.server.db.models import PickRow, Run, RunUser, User
+
+        with client.app.state.sessions() as session:
+            user_id = session.query(User).first().id
+            run = Run(trigger="manual", status="ok")
+            session.add(run)
+            session.flush()
+            session.add(
+                RunUser(
+                    run_id=run.id,
+                    user_id=user_id,
+                    status="ok",
+                    # A blob written before provenance existed: picks without sources/affinity.
+                    breakdown=[
+                        {
+                            "row_slug": "picked",
+                            "row_title": "Picked",
+                            "library_key": "1",
+                            "picks": [{"rank": 1, "title": "Torchwood", "tmdb_id": 55, "media_type": "show"}],
+                        }
+                    ],
+                )
+            )
+            session.add(
+                PickRow(
+                    run_id=run.id,
+                    user_id=user_id,
+                    tmdb_id=55,
+                    media_type="show",
+                    rating_key=1,
+                    rank=1,
+                    title="Torchwood",
+                    sources="tmdb_similar",
+                    affinity=0.28,
+                )
+            )
+            session.commit()
+            run_id = run.id
+
+        entry = client.get(f"/api/runs/{run_id}").json()["users"][0]["breakdown"][0]["picks"][0]
+
+        assert entry["sources"] == ["tmdb_similar"]
+        assert entry["affinity"] == 0.28
+
+    def test_a_breakdown_pick_with_no_matching_row_is_left_alone(self, client: TestClient):
+        """Never invent provenance: a pick the picks table doesn't know about stays blank, which the
+        UI renders as nothing rather than as a confident claim."""
+        from shortlist.server.db.models import Run, RunUser, User
+
+        with client.app.state.sessions() as session:
+            user_id = session.query(User).first().id
+            run = Run(trigger="manual", status="ok")
+            session.add(run)
+            session.flush()
+            session.add(
+                RunUser(
+                    run_id=run.id,
+                    user_id=user_id,
+                    status="ok",
+                    breakdown=[
+                        {
+                            "row_slug": "picked",
+                            "library_key": "1",
+                            "picks": [{"rank": 1, "title": "Unknown", "tmdb_id": 999, "media_type": "movie"}],
+                        }
+                    ],
+                )
+            )
+            session.commit()
+            run_id = run.id
+
+        entry = client.get(f"/api/runs/{run_id}").json()["users"][0]["breakdown"][0]["picks"][0]
+
+        assert "sources" not in entry or entry["sources"] == []
+
     def test_a_failed_run_exposes_why_not_just_that_it_failed(self, client: TestClient):
         """The reason lived only inside `stats`, which no client read — so a run that failed for a
         run-level reason (a share filter Plex refused) surfaced as a bare "Failed" and the operator


### PR DESCRIPTION
Promotes `dev` to `master` for beta.5.

**The run page really does show pick provenance now.** There are three places that build a pick, and
the run page renders the one that was still missing it — a stored per-(row, library) breakdown blob,
not the picks table. beta.4 fixed the renderer; the data feeding it was still blank.

Existing runs are backfilled at read time by joining the breakdown to the picks rows, so runs already
recorded explain themselves instead of staying blank until rebuilt. A pick with no matching row stays
blank rather than being given an invented source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)