### PR TITLE
feat(ui): make the wordmark link to the dashboard

### DIFF
--- a/web/src/components/brand.tsx
+++ b/web/src/components/brand.tsx
@@ -1,4 +1,5 @@
 import { Sparkles } from "lucide-react";
+import { Link } from "react-router";
 
 import { cn } from "@/lib/utils";
 
@@ -31,7 +32,10 @@ export function Logo({
   );
 }
 
-/** The mark plus the wordmark — the app's identity lockup. */
+/** The mark plus the wordmark — the app's identity lockup.
+ *
+ *  Not a link itself: the login and setup screens show it while signed out, where a link to the
+ *  dashboard would go nowhere useful. `app-shell` wraps it in one via {@link HomeWordmark}. */
 export function Wordmark({
   size = "md",
   className,
@@ -43,7 +47,27 @@ export function Wordmark({
   return (
     <span className={cn("inline-flex items-center gap-2.5", className)}>
       <Logo size={size} />
-      <span className={cn("font-semibold tracking-tight", s.text)}>Shortlist</span>
+      <span className={cn("font-semibold tracking-tight", s.text)}>
+        Shortlist
+      </span>
     </span>
+  );
+}
+
+/** The wordmark as a link to the dashboard — the convention everywhere else on the web, so people
+ *  try it. Used in all three chrome slots (mobile bar, drawer, desktop rail); inside the drawer it
+ *  needs no close handler, since the drawer already closes on any `<a>` tapped within it.
+ *
+ *  Kept distinct from {@link Wordmark} because the login and setup screens render the plain mark
+ *  while signed out, where a dashboard link would go nowhere useful. */
+export function HomeWordmark({ size }: { size?: keyof typeof SIZES }) {
+  return (
+    <Link
+      to="/"
+      aria-label="Shortlist — go to dashboard"
+      className="rounded-md transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <Wordmark size={size} />
+    </Link>
   );
 }

--- a/web/src/components/layout/app-shell.tsx
+++ b/web/src/components/layout/app-shell.tsx
@@ -19,7 +19,7 @@ import {
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router";
 
-import { Wordmark } from "@/components/brand";
+import { HomeWordmark } from "@/components/brand";
 import { ActivityPill } from "@/components/layout/activity-pill";
 import { NotificationBell } from "@/components/layout/notification-bell";
 import { SettingsSubNav } from "@/components/settings/settings-nav";
@@ -224,7 +224,7 @@ export function AppShell() {
     <div className="flex min-h-screen flex-col md:flex-row">
       {/* Mobile top bar: wordmark + hamburger. Hidden once the sidebar appears at md. */}
       <header className="sticky top-0 z-30 flex items-center justify-between border-b bg-card/80 px-4 py-3 backdrop-blur md:hidden">
-        <Wordmark />
+        <HomeWordmark />
         <div className="flex items-center gap-1">
           <NotificationBell align="right" />
           <Button
@@ -263,7 +263,7 @@ export function AppShell() {
             }}
           >
             <div className="flex items-center justify-between border-b px-4 py-3">
-              <Wordmark />
+              <HomeWordmark />
               <Button
                 variant="ghost"
                 size="icon"
@@ -285,7 +285,7 @@ export function AppShell() {
           OVER that overflow (the "text shows behind the panel" bug). Elevating the whole rail fixes it. */}
       <aside className="sticky top-0 z-30 hidden h-screen w-60 shrink-0 flex-col border-r bg-card/40 backdrop-blur md:flex">
         <div className="flex items-center justify-between px-5 py-5">
-          <Wordmark />
+          <HomeWordmark />
           <NotificationBell align="left" />
         </div>
         <NavBody />

--- a/web/src/test/brand-home-link.test.tsx
+++ b/web/src/test/brand-home-link.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { HomeWordmark, Logo, Wordmark } from "@/components/brand";
+
+/**
+ * The wordmark in the app chrome links to the dashboard — the convention everywhere else on the
+ * web, so people try it. The bare `Logo`/`Wordmark` must NOT link on their own: the login and setup
+ * screens render them while signed out, where a dashboard link goes nowhere useful.
+ */
+describe("brand marks", () => {
+  it("does not wrap the wordmark in a link on its own", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Wordmark />
+      </MemoryRouter>,
+    );
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("does not wrap the bare logo in a link (login screen renders it signed out)", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Logo size="lg" />
+      </MemoryRouter>,
+    );
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("HomeWordmark points at the dashboard with an accessible name", () => {
+    // Asserting href AND accessible name together: the mark is aria-hidden, so without the label
+    // the link would only announce by accident of the wordmark's text contents.
+    render(
+      <MemoryRouter>
+        <HomeWordmark />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", {
+      name: "Shortlist — go to dashboard",
+    });
+    expect(link).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
Clicking the mark top-left is the convention everywhere else on the web, so people try it — and nothing happened.

## Approach

Lives in `brand.tsx` as `HomeWordmark` rather than wrapping at the three call sites, so the behaviour is testable directly rather than only through `app-shell` (which needs session/query context to render).

Deliberately kept separate from `Wordmark`: the login and setup screens render the plain mark **while signed out**, where a dashboard link goes nowhere useful. Login uses the bare `Logo` and is unaffected.

- Used in all three chrome slots — mobile top bar, mobile drawer, desktop rail
- **No close handler needed in the drawer**: it already closes on any `<a>` tapped inside it (`app-shell.tsx:260`)
- Carries an explicit `aria-label` because the mark is `aria-hidden` — without one the link would only announce by accident of the wordmark's text contents
- `focus-visible` ring, per the frontend accessibility rules

## Test

Asserts href *and* accessible name together, plus that the bare `Wordmark` and `Logo` do **not** render a link — that's the regression that would break the signed-out screens.

Confirmed it has teeth rather than assuming:

```
link pointed at /rows  → FAIL  (1 failed | 2 passed)
restored to /          → PASS  (3 passed)
```

346 tests pass, lint 0 errors, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)