### PR TITLE
Promote dev → master: dead /plexdb mount removed, Docker named as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ picks your server, and walks you to your first rows (about 10 minutes).
 > 💡 Want to try it without touching your server first? Add `-e SHORTLIST_DRY_RUN=1` — Shortlist
 > will show you exactly what it _would_ do and write nothing to Plex.
 
-Requirements: Plex Media Server ≥ 1.43.2.10687 · Plex Pass on the admin account · a free TMDB key.
-Optional: Tautulli, an LLM key. Details in [Getting started](docs/getting-started.md).
+Requirements: somewhere to run a Docker container (it does not have to be the same machine as Plex,
+just able to reach it) · Plex Media Server ≥ 1.43.2.10687 · Plex Pass on the admin account · a free
+TMDB key. Optional: Tautulli, an LLM key. Details in [Getting started](docs/getting-started.md).
 
 ## Documentation
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -6,11 +6,6 @@ services:
       - "5959:5959"
     volumes:
       - ./config:/config
-      # Optional, and only if Shortlist runs on the same machine as Plex: mounting Plex's database
-      # READ-ONLY lets Shortlist see titles people MARKED watched. Plex's history API only reports
-      # what was actually played, so without this a marked-watched title can be recommended back.
-      # Then set Settings -> Advanced -> "Read watched state from the Plex database" to /plexdb.
-      # - "/path/to/plex/Library/Application Support/Plex Media Server/Plug-in Support/Databases:/plexdb:ro"
     environment:
       - TZ=Etc/UTC
       - PUID=1000

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,10 @@ heading: Getting started
 
 ## Requirements
 
+- **Somewhere to run a Docker container.** Shortlist ships as a Docker image and is installed by
+  running that container — on Windows, macOS, Linux, a NAS (Synology, QNAP, unRAID), or anything
+  else that runs Docker. It does **not** have to be the same machine as Plex; it only needs to be
+  able to reach your Plex server over the network.
 - **Plex Media Server 1.43.2.10687 or newer** — this is the version where Plex started honouring
   the setting that hides each row. On anything older, a private row could show up for other people.
   The wizard checks your version before you begin, so you'll know straight away.

--- a/docs/guides/rows.md
+++ b/docs/guides/rows.md
@@ -113,9 +113,11 @@ quota is spent, the row falls back to TMDB for its _whole_ ordering rather than 
 on one scale and half on another.
 
 **Shuffled** and **Taking turns** are the two with a cost worth knowing about. The other four are
-applied while the row is being written anyway, so they are free; these two rewrite the collection on
-Plex every day, including days when nothing about the row has changed. On a server with many people
-that is real write volume, so neither is on by default.
+applied while the row is being written anyway, so they are free; these two reorder the row on Plex
+every day, including days when nothing about the row has changed. It is the front of the row that
+moves — the first 15 titles, which is what shows on the Home shelf before "see all" — so the cost is
+bounded per row, but it is one Plex write per title moved, per person, per night. On a server with
+many people that is real write volume, so neither is on by default.
 
 Both are stable within a day. Re-running a row the same night reproduces the same order, and two
 people's copies of one row shuffle differently.

--- a/shortlist/server/api/settings.py
+++ b/shortlist/server/api/settings.py
@@ -326,7 +326,14 @@ async def put_settings(update: SettingsUpdate, request: Request) -> dict:
     _validate_values(update.values)
     _reject_blocked_urls(update.values)
     await _reject_a_different_server(request.app.state, update.values)
+    from shortlist.server.api.system import invalidate_plex_reads
     from shortlist.server.scheduler import DEFAULT_CRONS
+
+    # A new URL or token may point at a different server, and the library list is cached by READ
+    # rather than by server — so without this the picker would offer the previous server's libraries
+    # for up to the cache TTL. Cheap, and only on a settings write.
+    if {"plex.url", "plex.token"} & set(update.values):
+        invalidate_plex_reads(request.app.state)
 
     with request.app.state.sessions() as session:
         store = SettingsStore(session, request.app.state.secrets)

--- a/shortlist/server/api/settings.py
+++ b/shortlist/server/api/settings.py
@@ -82,6 +82,22 @@ class SettingsUpdate(BaseModel):
     values: dict[str, object]
 
 
+def _re_points_plex(values: dict[str, object]) -> bool:
+    """Whether this write actually changes which Plex server we talk to.
+
+    Mirrors the write loop's own skip: a redacted token round-tripped from the UI is not a new value,
+    so it must not count. Treating it as a re-point would throw the cached library list away every
+    time anyone saved the Settings page, putting Plex back on the next page load for no reason.
+    """
+    for key in ("plex.url", "plex.token"):
+        if key not in values:
+            continue
+        if key in SECRET_KEYS and values[key] == REDACTED_PLACEHOLDER:
+            continue
+        return True
+    return False
+
+
 class CuratorModelsRequest(BaseModel):
     """Optional live overrides from the settings form so the model picker can list the provider being
     edited BEFORE it's saved. Any blank field falls back to the saved setting; a redacted api key
@@ -329,12 +345,6 @@ async def put_settings(update: SettingsUpdate, request: Request) -> dict:
     from shortlist.server.api.system import invalidate_plex_reads
     from shortlist.server.scheduler import DEFAULT_CRONS
 
-    # A new URL or token may point at a different server, and the library list is cached by READ
-    # rather than by server — so without this the picker would offer the previous server's libraries
-    # for up to the cache TTL. Cheap, and only on a settings write.
-    if {"plex.url", "plex.token"} & set(update.values):
-        invalidate_plex_reads(request.app.state)
-
     with request.app.state.sessions() as session:
         store = SettingsStore(session, request.app.state.secrets)
         # Two settings do real work on Plex, so their OLD values are read before the write. Storing
@@ -379,6 +389,17 @@ async def put_settings(update: SettingsUpdate, request: Request) -> dict:
         now_hiding = bool(store.get("privacy.hide_shared_from_disabled"))
         new_row_name = (store.get("row.name_template") or "") if "row.name_template" in update.values else old_row_name
         result = store.all_public()
+
+    # A new URL or token may point at a different server, and the library list is cached by READ
+    # rather than by server — so without this the picker would offer the previous server's libraries
+    # for up to the cache TTL. Cheap, and only on a settings write.
+    #
+    # AFTER the write commits, never before it: `/libraries` runs its read on an executor thread, so
+    # it genuinely interleaves with this handler. A read landing between an early drop and the commit
+    # re-populates the cache from the OLD url/token and pins it for the whole TTL — precisely the
+    # staleness this exists to prevent.
+    if _re_points_plex(update.values):
+        invalidate_plex_reads(request.app.state)
 
     # Both of these change what is on somebody's Plex server, so they act NOW rather than waiting for
     # a run. Outside the session block: each queues a job that opens its own.

--- a/shortlist/server/api/system.py
+++ b/shortlist/server/api/system.py
@@ -360,6 +360,18 @@ _PLEX_READ_TTL_S = 120.0
 _INTERACTIVE_TIMEOUT_S = 8
 
 
+def invalidate_plex_reads(state) -> None:
+    """Forget every cached Plex read. Called when the connected server may have changed.
+
+    The cache key is the READ, not the server — so after re-pointing Shortlist at a different PMS the
+    old server's library list would have been served for up to the TTL. Harmless (both endpoints are
+    owner-only and read the owner's own server, and nothing cached decides a write) but confusing:
+    the picker offers libraries the new server does not have.
+    """
+    state.__dict__.pop("_plex_read_cache", None)
+    state.__dict__.pop("_plex_read_locks", None)
+
+
 def _cached_plex_read(state, key: str, read):
     """Read from the PMS at most once per `_PLEX_READ_TTL_S` per key, and never twice at once.
 
@@ -391,7 +403,14 @@ def _cached_plex_read(state, key: str, read):
         try:
             value = read()
         except HTTPException:
-            raise  # "Plex isn't connected" is an answer, not a failure to paper over
+            # "Plex isn't connected" / "no such library" is an answer, not a failure to paper over.
+            # The lock goes with it: `key` carries a caller-supplied path segment, so keeping one per
+            # value ever asked for would grow this dict for as long as the process lives. Anyone
+            # already waiting holds their own reference, so dropping it here is safe — the worst case
+            # is one extra concurrent read of a key that just 404'd.
+            if key not in cache:
+                locks.pop(key, None)
+            raise
         except Exception as e:
             if entry is None:
                 raise

--- a/shortlist/server/api/system.py
+++ b/shortlist/server/api/system.py
@@ -413,6 +413,12 @@ def _cached_plex_read(state, key: str, read):
             raise
         except Exception as e:
             if entry is None:
+                # Same reasoning as the HTTPException arm: nothing was cached, so this key leaves no
+                # entry behind and its lock must go with it. The failure that actually grows the dict
+                # lands HERE rather than there — a bogus library key while the PMS is timing out
+                # raises a plexapi error, not an HTTPException.
+                if key not in cache:
+                    locks.pop(key, None)
                 raise
             logger.warning("plex read {} failed ({}) — serving the cached copy", key, type(e).__name__)
             return entry[1]

--- a/shortlist/server/services/jobs.py
+++ b/shortlist/server/services/jobs.py
@@ -125,8 +125,9 @@ CATALOG: tuple[JobKind, ...] = (
             "put in front of someone was actually watched — the numbers on your dashboard come from "
             "it. Reads only: nothing on Plex changes and nobody's rows move."
             "\n\nRuns at 04:17 by default. Normally it reads only what changed since the last pass, "
-            "with one complete re-read a week — that full pass is the only thing that can notice a "
-            "title being un-watched or removed from the library."
+            "with one complete re-read a week. The nightly pass spots a title un-watched recently; "
+            "that weekly one is what notices an un-watch further back than it reaches, or a title "
+            "removed from the library."
         ),
         manual=True,
         writes_plex=False,  # "Reads only — nothing on Plex changes", as the description says

--- a/shortlist/server/services/jobs.py
+++ b/shortlist/server/services/jobs.py
@@ -125,7 +125,8 @@ CATALOG: tuple[JobKind, ...] = (
             "put in front of someone was actually watched — the numbers on your dashboard come from "
             "it. Reads only: nothing on Plex changes and nobody's rows move."
             "\n\nRuns at 04:17 by default. Normally it reads only what changed since the last pass, "
-            "with one complete re-read a week. The nightly pass spots a title un-watched recently; "
+            "with one complete re-read a week. On servers that report a full result count the nightly "
+            "pass spots a title un-watched recently; "
             "that weekly one is what notices an un-watch further back than it reaches, or a title "
             "removed from the library."
         ),

--- a/tests/integration/test_api_system.py
+++ b/tests/integration/test_api_system.py
@@ -300,12 +300,15 @@ class TestSystemResponseShapes:
         page wanting a library list queued behind it. The list changes when someone adds a library."""
         from types import SimpleNamespace
 
+        import shortlist.server.api.system as system_api
+
         self._connect_plex(client)
         reads = {"n": 0}
+        built: list[dict] = []
 
         class FakePlex:
             def __init__(self, *a, **k):
-                pass
+                built.append(k)
 
             def sections(self):
                 reads["n"] += 1
@@ -318,6 +321,9 @@ class TestSystemResponseShapes:
 
         assert first == again
         assert reads["n"] == 1, "the second page load must not go back to Plex"
+        # The timeout is what bounds how long the single-flight lock is held. At the 20s default,
+        # one page load could hold it for four retries plus backoff while everyone else waits.
+        assert built[0]["timeout"] == system_api._INTERACTIVE_TIMEOUT_S
 
     def test_a_plex_that_fails_after_a_good_read_serves_the_cached_copy(self, client: TestClient, monkeypatch):
         """A library list two minutes old is a far better answer than a broken page, and it is used
@@ -348,6 +354,65 @@ class TestSystemResponseShapes:
 
         assert client.get("/api/system/libraries").json() == good
         assert system_api._PLEX_READ_TTL_S > 0  # the knob this behaviour hangs off still exists
+
+    def test_an_unknown_library_leaves_no_lock_behind(self, client: TestClient, monkeypatch):
+        """`key` is a caller-supplied path segment, so a lock kept per value ever asked for would
+        grow for as long as the process lives. Owner-authed, so this is hygiene rather than a DoS —
+        but an unbounded dict keyed on request input is worth not having."""
+        from types import SimpleNamespace
+
+        self._connect_plex(client)
+
+        class FakePlex:
+            def __init__(self, *a, **k):
+                pass
+
+            def sections(self):
+                return [SimpleNamespace(key=1, title="Movies", type="movie")]
+
+        monkeypatch.setattr("shortlist.engine.clients.plex_pms.PlexClient", FakePlex)
+
+        for bogus in ("999", "998", "997"):
+            assert client.get(f"/api/system/libraries/{bogus}/collections").status_code == 404
+
+        locks = client.app.state.__dict__.get("_plex_read_locks", {})
+        assert not [k for k in locks if k.startswith("collections:99")], f"locks accumulated: {locks}"
+
+    def test_re_pointing_plex_drops_the_cached_library_list(self, client: TestClient, monkeypatch):
+        """The cache is keyed by the READ, not by the server, so a connection change has to clear it.
+
+        Note what is NOT the risk here: pointing at a DIFFERENT machine is refused outright (409 —
+        switching servers is a re-link, not a settings edit), so the cache can never straddle two
+        servers. What this covers is the reachable case — the same server at a new address or with a
+        rotated token — plus any future path that writes those keys.
+        """
+        from types import SimpleNamespace
+
+        self._connect_plex(client)
+        current = {"title": "Movies"}
+
+        class FakePlex:
+            # Matches the linked server in the fixture, so re-pointing is allowed rather than 409'd.
+            machine_id = "m1"
+
+            def __init__(self, *a, **k):
+                pass
+
+            def sections(self):
+                return [SimpleNamespace(key=1, title=current["title"], type="movie")]
+
+        monkeypatch.setattr("shortlist.engine.clients.plex_pms.PlexClient", FakePlex)
+        assert client.get("/api/system/libraries").json()[0]["title"] == "Movies"
+
+        current["title"] = "Films"
+        # An unrelated setting must NOT throw the cache away — that would put Plex back on every page
+        # load for anyone who touches Settings.
+        assert client.put("/api/settings", json={"values": {"row.size": 12}}).status_code == 200
+        assert client.get("/api/system/libraries").json()[0]["title"] == "Movies"
+
+        saved = client.put("/api/settings", json={"values": {"plex.url": "http://pms-new:32400"}})
+        assert saved.status_code == 200, saved.text
+        assert client.get("/api/system/libraries").json()[0]["title"] == "Films"
 
     def test_a_plex_that_fails_with_nothing_cached_still_errors(self, client: TestClient, monkeypatch):
         """Serving stale is a kindness, not a cover-up: with no previous answer there is nothing

--- a/tests/integration/test_api_system.py
+++ b/tests/integration/test_api_system.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from shortlist.server.api.settings import REDACTED_PLACEHOLDER
 from shortlist.server.auth import SESSION_COOKIE
 from shortlist.server.settings_store import SettingsStore
 
@@ -413,6 +414,63 @@ class TestSystemResponseShapes:
         saved = client.put("/api/settings", json={"values": {"plex.url": "http://pms-new:32400"}})
         assert saved.status_code == 200, saved.text
         assert client.get("/api/system/libraries").json()[0]["title"] == "Films"
+
+        # A REAL token change re-points the same way a URL does.
+        current["title"] = "Cinema"
+        saved = client.put("/api/settings", json={"values": {"plex.token": "rotated-token"}})
+        assert saved.status_code == 200, saved.text
+        assert client.get("/api/system/libraries").json()[0]["title"] == "Cinema"
+
+        # ...but the placeholder the UI round-trips for a secret it never received is NOT a change —
+        # the write loop skips it, so the cache must survive it for the same reason `row.size` does.
+        # Otherwise saving the Settings page at all puts Plex back on the next page load.
+        current["title"] = "Pictures"
+        saved = client.put("/api/settings", json={"values": {"plex.token": REDACTED_PLACEHOLDER}})
+        assert saved.status_code == 200, saved.text
+        assert client.get("/api/system/libraries").json()[0]["title"] == "Cinema"
+
+    def test_the_cache_drop_lands_after_the_new_connection_commits(self, client: TestClient, monkeypatch):
+        """Dropping the cache BEFORE the write commits re-caches the server you just left.
+
+        `/libraries` runs its read on an executor thread, so it genuinely interleaves with a
+        `put_settings` that has not committed yet: the read repopulates the entry from the OLD
+        url/token and pins it for the whole TTL — the exact staleness the drop exists to prevent.
+
+        Asserting the ORDER is what gives this teeth. "The cache ends up empty" passes just as
+        happily with the drop back on the wrong side of the commit.
+        """
+        from types import SimpleNamespace
+
+        import shortlist.server.api.system as system_module
+
+        self._connect_plex(client)
+
+        class FakePlex:
+            machine_id = "m1"
+
+            def __init__(self, *a, **k):
+                pass
+
+            def sections(self):
+                return [SimpleNamespace(key=1, title="Movies", type="movie")]
+
+        monkeypatch.setattr("shortlist.engine.clients.plex_pms.PlexClient", FakePlex)
+
+        seen: dict[str, object] = {}
+        real = system_module.invalidate_plex_reads
+
+        def spy(state):
+            # What a concurrent reader would find in the DB at the instant the cache is dropped.
+            with client.app.state.sessions() as session:
+                seen["url"] = SettingsStore(session, client.app.state.secrets).get("plex.url")
+            return real(state)
+
+        # `put_settings` imports this inside the function, so patching the source module is what lands.
+        monkeypatch.setattr(system_module, "invalidate_plex_reads", spy)
+
+        saved = client.put("/api/settings", json={"values": {"plex.url": "http://pms-new:32400"}})
+        assert saved.status_code == 200, saved.text
+        assert seen["url"] == "http://pms-new:32400"
 
     def test_a_plex_that_fails_with_nothing_cached_still_errors(self, client: TestClient, monkeypatch):
         """Serving stale is a kindness, not a cover-up: with no previous answer there is nothing


### PR DESCRIPTION
Promotes 2 commits from `dev`. **This is not a release** — the `docker` job publishes only on `dev` pushes and `v*` tags, so a `master` push runs the five test jobs and publishes nothing. No `v1.0.1` tag is intended.

## Why now

The install instructions in both README and `docs/getting-started.md` tell users to `curl` the compose file from **`master`**:

```
raw.githubusercontent.com/stevezau/shortlist/master/docker-compose.example.yml
```

That file on `master` still advertises mounting Plex's database read-only and points at a **Settings → Advanced → "Read watched state from the Plex database"** option that migration `0038` deleted. It was the only place in the repo implying Shortlist must run on Plex's machine, and a v1.0.0 user on r/PlexServers read it exactly that way — then went looking for a setting that no longer exists in the UI.

The default branch is `dev` and GitHub Pages builds from `dev` `/docs`, so the corrected docs are already public. Only the compose file is gated behind this promotion, which leaves the docs and the file they download contradicting each other until it merges.

## Commits

- `71edea6` **docs:** drop the dead `/plexdb` mount and name Docker as a requirement. Watched state has come from the PMS API per user via the share token since `0038`, `viewCount`/`viewedLeafCount` included, so marks-as-watched are already covered and nothing reads that mount. Requirements also never named Docker itself, so a Windows Server user with no container runtime had no signal one was needed — both places now say it, and say it need not be Plex's machine.
- `fb2c8c9` **fix:** clear the five LOW findings from the v1.0.0 release review.

## Verification

- `docker-compose.example.yml` parses; `./config:/config` is the only remaining volume
- No references to `plexdb` / `plex.db_path` / "Read watched state" remain anywhere outside migration `0038`'s own docstring
- Architecture Review dispatched per the release-PR convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)