### PR TITLE
Release 1.6.1 — review fixes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,8 +34,9 @@ Yes, and it has to. Plex shows a collection to anyone who isn't explicitly told 
 Shortlist only touched the accounts you gave rows to, **everyone else would see those private
 rows**.
 
-So it adds hide-this-label rules to every account your server is shared with. Nothing else in their
-settings is touched. Shortlist reads what's there, adds only its own entries, and leaves the rest
+So it adds hide-this-label rules to every account your server is shared with — unless you've asked
+it to leave one alone, which you can do per person if their own Plex restrictions clash with ours.
+Nothing else in their settings is touched. Shortlist reads what's there, adds only its own entries, and leaves the rest
 exactly as they were. The original is saved first, and Uninstall restores all of them.
 
 ## Do I get a row myself?

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -67,7 +67,10 @@ faster than a list of questions: _"open /issue, switch the checks on, type the t
   **shared row can't reach its threshold**. A shared row is built only from titles several people
   have watched, so it needs at least 2 enabled users with viewing in common and will skip forever
   below that. Make it a per-person row instead if you want one person to get it.
-- **A user says they can see someone else's row** — run Shortlist again (Run now): every run
+- **A user says they can see someone else's row** — first check they aren't badged **Sharing
+  untouched** in Users: that means you asked Shortlist to leave their Plex account alone, so it
+  writes no exclusions for them and re-running will never change it (turn **Manage their Plex
+  sharing settings** back on for them). Otherwise run Shortlist again (Run now): every run
   re-merges the `label!=` exclusions into each account's share filters. Check whether the share
   was edited by hand in plex.tv (Shortlist re-merges but never deletes filter conditions it
   didn't add), and confirm Plex Media Server is ≥ 1.43.2.10687 (older builds ignore the exclusion).

--- a/shortlist/server/api/support.py
+++ b/shortlist/server/api/support.py
@@ -91,6 +91,17 @@ _ERROR_LINES = 40
 _LABEL_PREFIX = "shortlist_"
 
 
+def _per_person_excludes(row: dict) -> list[str]:
+    """The Shortlist excludes on one account that "leave their sharing alone" would actually remove.
+
+    A restricted shared row's `shortlist__shared_*` exclude is deliberately kept, so it is not
+    evidence that a removal is owed. `_is_ours` matches on `shortlist_`, which a shared label also
+    starts with — the same collision that made the writer strip them in the first place.
+    """
+    shared = SHARED_LABEL_PREFIX.lower()
+    return [v for v in row["shortlist_excludes"] if not unquote(v).lower().startswith(shared)]
+
+
 def _is_ours(value: str) -> bool:
     """Is this filter value one of Shortlist's own labels?
 
@@ -2030,8 +2041,12 @@ async def sharing(request: Request) -> dict:
             # the same thing while a write is owed or permanently refused (a parental profile makes
             # plex.tv reject the removal for ever). Reporting intent as fact here would re-create
             # exactly what the comment at the top of this function exists to prevent.
-            cleared = [r["user"] for r in rows if not r["manage_sharing"] and not r["shortlist_excludes"]]
-            still_held = [r for r in rows if not r["manage_sharing"] and r["shortlist_excludes"]]
+            # PER-PERSON excludes only, matching what the writer actually removes. A restricted
+            # shared row's exclude is KEPT on purpose (`privacy.clear_our_excludes`), so counting it
+            # here reports a correct state as a permanent failure — and worse, makes the genuinely
+            # stuck case (a 422'd removal) indistinguishable from the normal one.
+            cleared = [r["user"] for r in rows if not r["manage_sharing"] and not _per_person_excludes(r)]
+            still_held = [r for r in rows if not r["manage_sharing"] and _per_person_excludes(r)]
             if cleared:
                 block.line(
                     f"Left alone by choice, so they hide nothing and can see other people's rows: "
@@ -2040,7 +2055,7 @@ async def sharing(request: Request) -> dict:
                 if len(cleared) > 8:
                     block.line(f"  …and {len(cleared) - 8} more")
             for row in still_held[:8]:
-                held = ", ".join(row["shortlist_excludes"][:6])
+                held = ", ".join(_per_person_excludes(row)[:6])
                 block.line(f"{row['user']} (#{row['account_id']}) is set to be left alone, but our exclusions are")
                 block.line(f"  STILL on this account — the removal has not gone through: {held}")
             if len(still_held) > 8:

--- a/shortlist/server/services/jobs.py
+++ b/shortlist/server/services/jobs.py
@@ -890,6 +890,12 @@ def _privacy_sync(state, payload: dict) -> dict:
         detail += f" after {reason}"
     if swept:
         detail += f"; swept {swept} unhidable row(s)"
+    # `privacy.sync` persists no run, so `report.left_alone_failures` has nowhere else to surface —
+    # and this handler is the one the "leave their sharing alone" PATCH fires. Without this the toast
+    # says the filters were merged while that account kept every exclude we promised to remove.
+    if report.left_alone_failures:
+        failed = len(report.left_alone_failures)
+        detail += f"; could NOT clear Shortlist's exclusions from {failed} left-alone account(s)"
     # This job repositions rows on the shelf now, and its own description promises it does. Reported
     # here in the same words `sync.check` uses, so the two jobs do not describe the same write
     # differently — the audit event is written either way (`_audit_hub_orderings`, rule 10); this is

--- a/shortlist/server/services/user_sync.py
+++ b/shortlist/server/services/user_sync.py
@@ -207,6 +207,11 @@ def _sync_owner(
     user.avatar_url = account.get("thumb") or ""
     user.friendly_name = friendly or user.friendly_name
     user.user_type = UserType.OWNER.value  # a pre-existing row for this account was never really "shared"
+    # Plex has no share filters for the owner, so "leave their sharing alone" stops meaning anything
+    # the moment an account becomes one. Cleared here as well as refused in `patch_user`, or an
+    # account that carried the flag before an owner transfer keeps badging the owner for a state
+    # that cannot exist.
+    user.manage_sharing = True
     return "updated"
 
 

--- a/tests/integration/test_api_support.py
+++ b/tests/integration/test_api_support.py
@@ -1236,6 +1236,58 @@ class TestSharingCountsLabelsNotClauses:
         assert row["shortlist_excludes"] == ["shortlist_ana", "shortlist_dan", "shortlist_mike"]
         assert "hides 3 of 4" in client.get("/api/support/sharing").json()["text"]
 
+    def test_a_kept_shared_row_exclude_is_not_reported_as_a_failed_removal(self, client, monkeypatch):
+        """Found by the v1.6.1 release review.
+
+        `clear_our_excludes` deliberately KEEPS a restricted shared row's exclude on a left-alone
+        account — it is the only thing hiding that row from someone outside its audience. This
+        report's split was matching on `shortlist_`, which `shortlist__shared_` also starts with, so
+        that correct state printed as "the removal has not gone through" on every report, for ever.
+        Which is worse than noise: it makes the genuinely stuck case — a plex.tv 422 that really did
+        leave our excludes behind — indistinguishable from the normal one.
+        """
+        from shortlist.server.db.models import User
+
+        self._accounts(
+            monkeypatch,
+            {"sarah": {"filterMovies": "label!=shortlist__shared_date_night", "filterTelevision": ""}},
+        )
+        _rows_on_plex(monkeypatch, ["mike"])
+        _enable(client)
+        with client.app.state.sessions() as session:
+            sarah = session.query(User).filter_by(username="sarah").one()
+            sarah.plex_account_id = 1000  # the id the faked plex.tv account above carries
+            sarah.manage_sharing = False
+            session.commit()
+
+        text = client.get("/api/support/sharing").json()["text"]
+
+        assert "the removal has not gone through" not in text
+        assert "Left alone by choice" in text
+
+    def test_a_per_person_exclude_left_behind_IS_reported(self, client, monkeypatch):
+        """The other half of the same split: a left-alone account still carrying a per-person exclude
+        means the removal is genuinely owed, and saying so is the whole point of the block."""
+        from shortlist.server.db.models import User
+
+        self._accounts(
+            monkeypatch,
+            {"sarah": {"filterMovies": "label!=shortlist__shared_date_night,shortlist_mike", "filterTelevision": ""}},
+        )
+        _rows_on_plex(monkeypatch, ["mike"])
+        _enable(client)
+        with client.app.state.sessions() as session:
+            sarah = session.query(User).filter_by(username="sarah").one()
+            sarah.plex_account_id = 1000  # the id the faked plex.tv account above carries
+            sarah.manage_sharing = False
+            session.commit()
+
+        text = client.get("/api/support/sharing").json()["text"]
+
+        assert "the removal has not gone through" in text
+        assert "shortlist_mike" in text
+        assert "shortlist__shared_date_night" not in text.split("has not gone through")[1]
+
     def test_a_foreign_label_in_our_clause_is_not_attributed_to_shortlist(self, client, monkeypatch):
         """The owner's own restriction, sharing the condition we merged into. Reporting it as ours
         would send someone hunting for a Shortlist bug in their own configuration."""


### PR DESCRIPTION
Follow-up to #93, which merged before the release review finished. No version change — still v1.6.1, not yet tagged.

The review's one MEDIUM, plus three LOWs. No HIGH findings; it judged the release safe to tag either way, but this lands the fix in the same file the release already touches rather than carrying it as debt.

**The MEDIUM, and it's a self-inflicted one.** #93 made `clear_our_excludes` deliberately keep a restricted shared row's exclusion on a left-alone account — that exclusion is the only thing keeping the row away from someone outside its audience. But Support → Sharing, written in the same commit to report whether a removal actually landed, still matched on `shortlist_`, which `shortlist__shared_` also starts with. So a correct state printed as "the removal has not gone through" on every report, permanently — making a genuinely stuck removal (a plex.tv 422) indistinguishable from the normal case, on the one tool that exists to answer "is every row hidden from this person". Same prefix collision as the bug it reports on, one file away.

Also:
- Troubleshooting told the owner to re-run Shortlist when someone can see another person's row; there's now a deliberate cause a re-run can never fix, and it should be checked first. Same exception added to the FAQ's "every account your server is shared with".
- `privacy.sync` persists no run, so `left_alone_failures` had nowhere to surface — and that handler is the one the PATCH fires. The job detail now says when it couldn't clear an account instead of reporting filters merged.
- Promoting an account to owner left `manage_sharing=0` set, badging the owner with a state that can't exist (already refused at the API; now cleared on promotion too).

Two tests, both halves of the split: a kept shared exclusion is not reported as owed, and a per-person one still is. Proved to bite by reverting the fix first.

Backend 2599 passed (94.30%), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)