### PR TITLE
feat: implement APP_BASE_PATH so the app can be served from a subpath

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,7 +21,7 @@ heading: Reference
 ### Serving from a subpath
 
 Set `APP_BASE_PATH` and point the proxy at the container. No rebuild, and no prefix-stripping
-middleware — the app strips its own prefix, rewrites the asset URLs in the shell it serves, and
+middleware — the app recognises its own prefix, rewrites the asset URLs in the shell it serves, and
 publishes the prefix to the SPA so the router and API client use it too.
 
 ```yaml
@@ -47,10 +47,13 @@ http:
           - url: "http://shortlist:5959/"
 ```
 
-nginx — note there is no trailing slash on `proxy_pass`, so the prefix is forwarded intact:
+nginx — note there is no trailing slash on either the `location` or the `proxy_pass`. On
+`proxy_pass` it is what forwards the prefix intact; on `location` it is what lets `/shortlist`
+match as well as `/shortlist/`, so the bare URL people actually type reaches the app (which
+redirects it to `/shortlist/`) instead of being 404'd by nginx:
 
 ```nginx
-location /shortlist/ {
+location /shortlist {
     proxy_pass http://shortlist:5959;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -63,6 +66,11 @@ and is passed through untouched. That is also why the container's own healthchec
 an unprefixed `/api/system/health` on localhost, keeps working.
 
 Leaving it unset serves the shell's bytes exactly as they shipped.
+
+If the app comes up blank behind the proxy, check the container log first: it states the base path
+it is using at startup, and warns if `APP_BASE_PATH` held something it could not use (a query, a
+fragment, a space) — in which case it ignores it and serves from the root, which on its own looks
+exactly like a proxy problem.
 
 ## Settings keys (DB-backed; Settings UI or `PUT /api/settings`)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -47,13 +47,17 @@ http:
           - url: "http://shortlist:5959/"
 ```
 
-nginx — note there is no trailing slash on either the `location` or the `proxy_pass`. On
-`proxy_pass` it is what forwards the prefix intact; on `location` it is what lets `/shortlist`
-match as well as `/shortlist/`, so the bare URL people actually type reaches the app (which
-redirects it to `/shortlist/`) instead of being 404'd by nginx:
+nginx — two blocks. `location /shortlist` on its own is a *prefix* match, so it would also
+swallow a sibling app at `/shortlistings`; `^~ /shortlist/` matches only the real subtree, and the
+exact-match block redirects the bare URL people actually type. Note there is no trailing slash on
+`proxy_pass` — that is what forwards the prefix intact:
 
 ```nginx
-location /shortlist {
+location = /shortlist {
+    return 308 /shortlist/;
+}
+
+location ^~ /shortlist/ {
     proxy_pass http://shortlist:5959;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -67,10 +71,15 @@ an unprefixed `/api/system/health` on localhost, keeps working.
 
 Leaving it unset serves the shell's bytes exactly as they shipped.
 
-If the app comes up blank behind the proxy, check the container log first: it states the base path
-it is using at startup, and warns if `APP_BASE_PATH` held something it could not use (a query, a
-fragment, a space) — in which case it ignores it and serves from the root, which on its own looks
-exactly like a proxy problem.
+Test through the proxy, at `https://host/shortlist/`. A blank page at the container's own port —
+or at any URL without the prefix — is expected, not a fault: the app still answers there (that is
+how the healthcheck works), but the SPA it serves is built for the prefix and renders nothing
+outside it.
+
+If it is blank *through the proxy*, check the container log first: it states the base path it is
+using at startup, and warns if `APP_BASE_PATH` held something it could not use (a query, a
+fragment, a space, an escaped or relative path) — in which case it ignores it and serves from the
+root, which on its own looks exactly like a proxy problem.
 
 ## Settings keys (DB-backed; Settings UI or `PUT /api/settings`)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -16,6 +16,53 @@ heading: Reference
 | `LOG_LEVEL`                                                                | `DEBUG`   | **seed once**: initial value for the `log.level` setting; change it live in Settings → Advanced                                                                                                                                                                 |
 | `SHORTLIST_DRY_RUN`                                                        | unset     | live: when set (`1`/`true`), EVERY run is forced to dry-run. The app builds its clients and logs the would-be changes but writes NOTHING to Plex/plex.tv. Safe mode for a demo/test instance pointed at a real server (even a manual "Run now" can't modify it) |
 | `SHORTLIST_ENABLE_DOCS`                                                    | unset     | live: when set (`1`), exposes the API docs at `/api/docs` and `/api/openapi.json` (off by default)                                                                                                                                                              |
+| `APP_BASE_PATH`                                                            | `/`       | live: serve the app from a subpath behind a reverse proxy, e.g. `/shortlist`. Read at startup, so the published image works unmodified — no rebuild. Accepts `/shortlist` or `/shortlist/`. The proxy just forwards; it does not need to strip the prefix. See [Serving from a subpath](#serving-from-a-subpath). |
+
+### Serving from a subpath
+
+Set `APP_BASE_PATH` and point the proxy at the container. No rebuild, and no prefix-stripping
+middleware — the app strips its own prefix, rewrites the asset URLs in the shell it serves, and
+publishes the prefix to the SPA so the router and API client use it too.
+
+```yaml
+services:
+  shortlist:
+    image: ghcr.io/stevezau/shortlist:latest
+    environment:
+      - APP_BASE_PATH=/shortlist
+```
+
+Traefik — router and service only:
+
+```yaml
+http:
+  routers:
+    shortlist:
+      rule: "Host(`media.example.com`) && PathPrefix(`/shortlist`)"
+      service: shortlist
+  services:
+    shortlist:
+      loadBalancer:
+        servers:
+          - url: "http://shortlist:5959/"
+```
+
+nginx — note there is no trailing slash on `proxy_pass`, so the prefix is forwarded intact:
+
+```nginx
+location /shortlist/ {
+    proxy_pass http://shortlist:5959;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+```
+
+A proxy that strips the prefix anyway still works — an already-stripped path simply doesn't match
+and is passed through untouched. That is also why the container's own healthcheck, which requests
+an unprefixed `/api/system/health` on localhost, keeps working.
+
+Leaving it unset serves the shell's bytes exactly as they shipped.
 
 ## Settings keys (DB-backed; Settings UI or `PUT /api/settings`)
 

--- a/shortlist/server/auth.py
+++ b/shortlist/server/auth.py
@@ -219,6 +219,22 @@ def read_session(request: Request) -> dict | None:
         return None
 
 
+def _cookie_path(request: Request) -> str:
+    """The path to scope the session cookie to.
+
+    Starlette defaults to ``path="/"``, which hands `shortlist_session` to every other app on the
+    same hostname — and sharing a hostname with another app is the only reason to set
+    `APP_BASE_PATH` at all. Matched by the browser against the URL IT holds (`/shortlist/...`),
+    which is the same whether the proxy forwards the prefix or strips it, so this is correct in
+    both modes. Unset means `"/"`, i.e. exactly what every install does today.
+
+    This stops the neighbour's SERVER being sent the cookie. It cannot stop a script already
+    running on the same origin from using it — same-origin is one trust boundary and no cookie
+    attribute subdivides it. `getattr` because the unit-level auth tests build `app.state` by hand.
+    """
+    return getattr(request.app.state, "base_path", "") or "/"
+
+
 def _check_csrf(request: Request) -> None:
     if request.method not in ("GET", "HEAD", "OPTIONS") and request.headers.get(CSRF_HEADER) != "1":
         raise HTTPException(status_code=403, detail=f"missing {CSRF_HEADER} header")
@@ -429,6 +445,7 @@ async def poll_pin(pin_id: int, request: Request, response: Response) -> dict:
         httponly=True,
         samesite="lax",
         secure=request.url.scheme == "https",
+        path=_cookie_path(request),
     )
     # The Plex token NEVER goes to the browser. During first-time setup we hold it server-side,
     # keyed to this session, so the wizard can enumerate/probe/link servers without the SPA ever
@@ -475,6 +492,7 @@ class LogoutOut(BaseModel):
 
 
 @router.post("/logout", response_model=LogoutOut)
-async def logout(response: Response) -> dict:
-    response.delete_cookie(SESSION_COOKIE)
+async def logout(request: Request, response: Response) -> dict:
+    # Same path as the one it was set with, or the browser keeps the cookie and logout does nothing.
+    response.delete_cookie(SESSION_COOKIE, path=_cookie_path(request))
     return {"ok": True}

--- a/shortlist/server/base_path.py
+++ b/shortlist/server/base_path.py
@@ -1,0 +1,67 @@
+"""Runtime base path for serving the SPA under a reverse-proxy prefix."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+ENV_VAR = "APP_BASE_PATH"
+
+GLOBAL_NAME = "__SHORTLIST_BASE_PATH__"
+
+
+def resolve_base_path(raw: str | None) -> str:
+    """Normalise a configured base path to "" (root) or "/prefix"."""
+    if raw is None:
+        return ""
+    candidate = raw.strip()
+    if not candidate or candidate == "/":
+        return ""
+    if not candidate.startswith("/"):
+        candidate = f"/{candidate}"
+    return candidate.rstrip("/")
+
+
+def base_path_from_env(environ: dict[str, str] | None = None) -> str:
+    """Read and normalise APP_BASE_PATH from the process environment."""
+    source = os.environ if environ is None else environ
+    return resolve_base_path(source.get(ENV_VAR))
+
+
+def render_shell(html: str, base_path: str) -> str:
+    """Rewrite the built shell so it loads from, and knows about, `base_path`."""
+    if not base_path:
+        return html
+    rewritten = html.replace('="/assets/', f'="{base_path}/assets/')
+    # JS quoting is not enough in a <script>: the HTML parser ends the element at a
+    # literal "</script>" even inside a string.
+    literal = json.dumps(base_path).replace("</", "<\\/").replace("<!--", "<\\!--")
+    script = f"<script>window.{GLOBAL_NAME} = {literal};</script>"
+    return rewritten.replace("<head>", f"<head>{script}", 1)
+
+
+class BasePathMiddleware:
+    """Publish `base_path` as the ASGI ``root_path`` so routing skips the prefix.
+
+    ``path`` is left whole: Starlette subtracts ``root_path`` from it when matching,
+    so stripping here too would subtract it twice and 404 the ``/assets`` mount.
+    """
+
+    def __init__(self, app: Any, base_path: str) -> None:
+        self.app = app
+        self.base_path = base_path
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[Any]],
+        send: Callable[[Any], Awaitable[None]],
+    ) -> None:
+        if self.base_path and scope.get("type") in ("http", "websocket"):
+            path = scope.get("path", "")
+            if path == self.base_path or path.startswith(f"{self.base_path}/"):
+                scope = dict(scope)
+                scope["root_path"] = self.base_path
+        await self.app(scope, receive, send)

--- a/shortlist/server/base_path.py
+++ b/shortlist/server/base_path.py
@@ -4,16 +4,40 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections.abc import Awaitable, Callable
 from typing import Any
+
+from loguru import logger
 
 ENV_VAR = "APP_BASE_PATH"
 
 GLOBAL_NAME = "__SHORTLIST_BASE_PATH__"
 
+#: A base path is a URL path and nothing else. A value carrying a query, a fragment, a space or a
+#: protocol-relative "//" normalises without complaint and then matches no request path ever sent,
+#: so the app serves from the root while the SPA believes it is prefixed — a blank page with
+#: nothing in the log to explain it. The same value is interpolated into the shell's `src=`/`href=`
+#: attributes, which are NOT escaped (the injected script is), so refusing junk at this one
+#: boundary is what keeps it out of both sinks.
+#:
+#: Excluded by character rather than permitted by one, so a perfectly ordinary non-ASCII prefix
+#: (`/фильмы`) still works: what is refused is the set that either breaks an HTML attribute or
+#: cannot appear in a path the server is asked for. Requiring one or more non-slash characters per
+#: segment is what rejects a protocol-relative `//host`.
+_VALID_BASE_PATH = re.compile(r"^(?:/[^/\s\"'<>&?#\\\x00-\x1f]+)+$")
+
 
 def resolve_base_path(raw: str | None) -> str:
-    """Normalise a configured base path to "" (root) or "/prefix"."""
+    """Normalise a configured base path to "" (root) or "/prefix".
+
+    Args:
+        raw: The configured value, typically ``os.environ["APP_BASE_PATH"]``.
+
+    Returns:
+        ``""`` for a root deployment — including for a value this cannot use, which is reported
+        with a warning rather than raised, so one typo does not put the container in a crash loop.
+    """
     if raw is None:
         return ""
     candidate = raw.strip()
@@ -21,7 +45,18 @@ def resolve_base_path(raw: str | None) -> str:
         return ""
     if not candidate.startswith("/"):
         candidate = f"/{candidate}"
-    return candidate.rstrip("/")
+    candidate = candidate.rstrip("/")
+    if not candidate:
+        return ""
+    if not _VALID_BASE_PATH.match(candidate):
+        logger.warning(
+            "{}={!r} is not a usable URL path — serving from the server root instead. "
+            "Use a plain path with no query, fragment or spaces, e.g. /shortlist.",
+            ENV_VAR,
+            raw,
+        )
+        return ""
+    return candidate
 
 
 def base_path_from_env(environ: dict[str, str] | None = None) -> str:
@@ -31,9 +66,23 @@ def base_path_from_env(environ: dict[str, str] | None = None) -> str:
 
 
 def render_shell(html: str, base_path: str) -> str:
-    """Rewrite the built shell so it loads from, and knows about, `base_path`."""
+    """Rewrite the built shell so it loads from, and knows about, `base_path`.
+
+    Rewriting the HTML is enough only because the bundle contains no absolute asset URLs of its
+    own: the build emits a single JS and a single CSS file, both named here. Add a `React.lazy`
+    route or a webfont and Vite starts writing `/assets/...` INSIDE the JS/CSS, where nothing
+    rewrites it — the app would then break behind a prefix as a blank page, not a failing test.
+    Either move to a relative `base` in `vite.config.ts` at that point, or keep the bundle flat.
+    """
     if not base_path:
         return html
+    if "<head>" not in html:
+        # Loud, because the quiet version is a white screen: the assets would still load from the
+        # right place, so the app boots, and then every API call goes to the server root and 404s.
+        raise RuntimeError(
+            "the app shell has no <head> element, so the base path could not be published to the "
+            f"SPA — {ENV_VAR} cannot be honoured. This is a build problem, not a configuration one."
+        )
     rewritten = html.replace('="/assets/', f'="{base_path}/assets/')
     # JS quoting is not enough in a <script>: the HTML parser ends the element at a
     # literal "</script>" even inside a string.

--- a/shortlist/server/base_path.py
+++ b/shortlist/server/base_path.py
@@ -7,6 +7,7 @@ import os
 import re
 from collections.abc import Awaitable, Callable
 from typing import Any
+from urllib.parse import unquote
 
 from loguru import logger
 
@@ -48,7 +49,13 @@ def resolve_base_path(raw: str | None) -> str:
     candidate = candidate.rstrip("/")
     if not candidate:
         return ""
-    if not _VALID_BASE_PATH.match(candidate):
+    # A percent-escape or a dot segment survives the character check and then loses: the browser
+    # normalises `/a/../b` and decodes `%2f` before it asks, so what arrives never equals what was
+    # configured, and the prefix silently matches nothing.
+    decoded_or_relative = unquote(candidate) != candidate or any(
+        segment in (".", "..") for segment in candidate.split("/")
+    )
+    if decoded_or_relative or not _VALID_BASE_PATH.match(candidate):
         logger.warning(
             "{}={!r} is not a usable URL path — serving from the server root instead. "
             "Use a plain path with no query, fragment or spaces, e.g. /shortlist.",

--- a/shortlist/server/main.py
+++ b/shortlist/server/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import hmac
 import logging
 import os
@@ -308,6 +309,9 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
     # Added last so it runs first, before routing.
     app_base_path = base_path_from_env()
     if app_base_path:
+        # Said out loud once at startup: when a subpath install is misconfigured the symptom is a
+        # blank page, and the first question is always "what does the app think its prefix is".
+        logger.info("serving under the base path {} (APP_BASE_PATH)", app_base_path)
         app.add_middleware(BasePathMiddleware, base_path=app_base_path)
 
     app.include_router(auth.router, prefix="/api")
@@ -338,18 +342,34 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
         #: which leaves the browser to guess from `last-modified` — and a browser that guesses "still
         #: fresh" keeps both the old shell AND the old bundle it names, so a deploy is invisible
         #: until someone hard-refreshes. Reported 2026-08-25: an owner looking straight at wording
-        #: that had already shipped. `no-cache` means revalidate, not "do not store": the etag still
-        #: makes it a 304 on the overwhelmingly common unchanged case.
+        #: that had already shipped. `no-cache` means revalidate, not "do not store".
+        #: It does NOT currently save the round trip: `FileResponse` sets an `etag` but does no
+        #: conditional handling — `is_not_modified` lives in `StaticFiles`, which this route does
+        #: not use — so an unchanged shell is still answered with a full 200. The validator is worth
+        #: sending anyway, because a caching proxy in front of us can act on it even though we don't.
         SHELL_HEADERS = {"cache-control": "no-cache, must-revalidate"}
 
-        # Rendered once: APP_BASE_PATH cannot change without a restart.
-        base_path = app_base_path
-        shell_html = render_shell(index.read_text(encoding="utf-8"), base_path) if index.is_file() else None
+        # Rendered once: APP_BASE_PATH cannot change without a restart. Only ever built when
+        # there IS a prefix to write in, so a root install keeps serving the file straight off disk
+        # — same bytes, same `etag`/`last-modified` headers, no behaviour to re-verify.
+        shell_html = (
+            render_shell(index.read_text(encoding="utf-8"), app_base_path)
+            if app_base_path and index.is_file()
+            else None
+        )
+        # A rewritten shell is not the file on disk, so `FileResponse`'s validators (built from
+        # mtime + size) would describe the wrong bytes. Hash what we actually serve instead: a
+        # caching proxy in front of a subpath install is the whole point of this feature, and a
+        # response with no validator is one it can never revalidate cheaply.
+        shell_headers = SHELL_HEADERS
+        if shell_html is not None:
+            digest = hashlib.md5(shell_html.encode("utf-8"), usedforsecurity=False).hexdigest()
+            shell_headers = SHELL_HEADERS | {"etag": f'"{digest}"'}
 
         def shell_response() -> Response:
             if shell_html is None:
                 return FileResponse(index, headers=SHELL_HEADERS)
-            return HTMLResponse(shell_html, headers=SHELL_HEADERS)
+            return HTMLResponse(shell_html, headers=shell_headers)
 
         @app.get("/{path:path}", include_in_schema=False)
         async def spa(path: str):  # SPA fallback: every non-API path serves the app shell

--- a/shortlist/server/main.py
+++ b/shortlist/server/main.py
@@ -308,6 +308,8 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
 
     # Added last so it runs first, before routing.
     app_base_path = base_path_from_env()
+    # Read by `auth` to scope the session cookie; always set, so nothing has to guess.
+    app.state.base_path = app_base_path
     if app_base_path:
         # Said out loud once at startup: when a subpath install is misconfigured the symptom is a
         # blank page, and the first question is always "what does the app think its prefix is".
@@ -336,7 +338,9 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
     if WEB_DIST.exists():
         app.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
         web_root = WEB_DIST.resolve()
-        index = web_root / "index.html"
+        # `.resolve()`d because `target` is: the comparison below now decides whether the
+        # rewritten shell is served at all, and a symlinked index.html would fail it silently.
+        index = (web_root / "index.html").resolve()
         #: `index.html` is the only file that NAMES the hashed bundles, so it is the one file a
         #: browser must never reuse without asking. It was served with no `cache-control` at all,
         #: which leaves the browser to guess from `last-modified` — and a browser that guesses "still

--- a/shortlist/server/main.py
+++ b/shortlist/server/main.py
@@ -16,7 +16,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, HTMLResponse, Response
 
 import shortlist
 from shortlist.logging_config import configure_logging, normalize_level
@@ -37,6 +37,7 @@ from shortlist.server.api import (
     watching_account,
 )
 from shortlist.server.api import settings as settings_api
+from shortlist.server.base_path import BasePathMiddleware, base_path_from_env, render_shell
 from shortlist.server.db.models import Run, Server
 from shortlist.server.db.session import make_engine, make_session_factory, run_migrations
 from shortlist.server.scheduler import build_scheduler
@@ -304,6 +305,11 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
     )
     app.add_middleware(_SecurityHeaders)
 
+    # Added last so it runs first, before routing.
+    app_base_path = base_path_from_env()
+    if app_base_path:
+        app.add_middleware(BasePathMiddleware, base_path=app_base_path)
+
     app.include_router(auth.router, prefix="/api")
     for module in (
         setup,
@@ -336,6 +342,15 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
         #: makes it a 304 on the overwhelmingly common unchanged case.
         SHELL_HEADERS = {"cache-control": "no-cache, must-revalidate"}
 
+        # Rendered once: APP_BASE_PATH cannot change without a restart.
+        base_path = app_base_path
+        shell_html = render_shell(index.read_text(encoding="utf-8"), base_path) if index.is_file() else None
+
+        def shell_response() -> Response:
+            if shell_html is None:
+                return FileResponse(index, headers=SHELL_HEADERS)
+            return HTMLResponse(shell_html, headers=SHELL_HEADERS)
+
         @app.get("/{path:path}", include_in_schema=False)
         async def spa(path: str):  # SPA fallback: every non-API path serves the app shell
             if path:
@@ -345,11 +360,11 @@ def create_app(config_dir: Path | None = None) -> FastAPI:
                 # web_root before serving it as a file (plex-safety: secrets never leave the box).
                 target = (web_root / path).resolve()
                 if target.is_relative_to(web_root) and target.is_file():
-                    # The shell by any other route (`/index.html`) gets the same treatment; the
-                    # hashed assets under /assets are content-addressed and may be cached freely.
-                    headers = SHELL_HEADERS if target == index else None
-                    return FileResponse(target, headers=headers)
-            return FileResponse(index, headers=SHELL_HEADERS)
+                    # `/index.html` needs the same rewrite as the fallback shell.
+                    if target == index:
+                        return shell_response()
+                    return FileResponse(target)
+            return shell_response()
 
     return app
 

--- a/tests/e2e/test_base_path_e2e.py
+++ b/tests/e2e/test_base_path_e2e.py
@@ -1,0 +1,89 @@
+"""The app served from a subpath, driven by a real browser.
+
+The ASGI tests (`test_base_path_app.py`) prove the SERVER routes under a prefix. They cannot prove
+the half that runs in the browser: that the rewritten shell's bundle actually loads, that React
+Router's `basename` resolves a deep link, and that every request the SPA makes carries the prefix.
+Get any of those wrong and the symptom is a blank page in a deployment no other test runs in —
+which is precisely how this class of bug reaches someone's server.
+
+No fake Plex here on purpose: an unconfigured app still serves the shell, mounts React, routes, and
+calls the API, which is the whole surface under test. Adding a seeded server would test the wizard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from playwright.sync_api import Browser
+
+from shortlist.server.main import create_app
+from tests.e2e.conftest import _free_port, _ThreadedServer
+
+pytestmark = pytest.mark.e2e
+
+BASE = "/shortlist"
+
+
+@pytest.fixture
+def prefixed_url(tmp_path, monkeypatch) -> Iterator[str]:
+    """A real server that believes it lives at `/shortlist`, as a forwarding proxy would present it."""
+    monkeypatch.setenv("APP_BASE_PATH", BASE)
+    server = _ThreadedServer(create_app(config_dir=tmp_path), _free_port())
+    server.start()
+    server.wait_until_up(f"{BASE}/api/system/health")
+    yield f"http://127.0.0.1:{server.port}"
+    server.stop()
+
+
+def _watched_page(browser: Browser, url: str):
+    """A page that records everything that would show up as "it just doesn't work"."""
+    page = browser.new_context().new_page()
+    page.set_default_timeout(60_000)
+    console_errors: list[str] = []
+    failed: list[str] = []
+    api_calls: list[str] = []
+    page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+    page.on("requestfailed", lambda r: failed.append(r.url))
+    page.on("request", lambda r: api_calls.append(r.url) if "/api/" in r.url else None)
+    return page, console_errors, failed, api_calls
+
+
+def test_the_app_boots_and_talks_to_itself_under_the_prefix(browser: Browser, prefixed_url: str) -> None:
+    page, console_errors, failed, api_calls = _watched_page(browser, prefixed_url)
+    page.goto(f"{prefixed_url}{BASE}/", wait_until="networkidle")
+
+    # The shell alone renders an empty <div id="root">. Anything inside it means the bundle was
+    # found at the rewritten URL, parsed, and mounted — the asset rewrite reaching a real browser.
+    assert page.locator("#root > *").count() > 0, "React never mounted — the bundle did not load"
+
+    # The prefix reached the SPA, not just the server.
+    assert page.evaluate("window.__SHORTLIST_BASE_PATH__") == BASE
+
+    # Every API call carries the prefix. A single unprefixed one is the run-log Download bug.
+    assert api_calls, "the SPA made no API calls at all — it never got far enough to be a test"
+    unprefixed = [url for url in api_calls if f"{BASE}/api/" not in url]
+    assert unprefixed == [], f"API calls bypassed the base path: {unprefixed}"
+
+    assert failed == [], f"requests failed under the prefix: {failed}"
+    assert console_errors == [], f"console errors under the prefix: {console_errors}"
+
+    page.context.close()
+
+
+def test_a_deep_link_survives_a_reload(browser: Browser, prefixed_url: str) -> None:
+    """`basename` has to strip the prefix before matching, and put it back when navigating.
+
+    Loading a nested route directly is the case a wrong `basename` breaks: the router sees a path
+    it cannot match and renders nothing, so the page is blank with a 200 and no console error.
+    """
+    page, console_errors, failed, _ = _watched_page(browser, prefixed_url)
+    page.goto(f"{prefixed_url}{BASE}/settings", wait_until="networkidle")
+
+    assert page.locator("#root > *").count() > 0, "the router matched nothing under the prefix"
+    # Wherever the app decided to send an unconfigured visitor, it must stay inside the prefix.
+    assert page.url.startswith(f"{prefixed_url}{BASE}/"), f"navigated out of the base path: {page.url}"
+    assert failed == []
+    assert console_errors == []
+
+    page.context.close()

--- a/tests/e2e/test_base_path_e2e.py
+++ b/tests/e2e/test_base_path_e2e.py
@@ -42,15 +42,15 @@ def _watched_page(browser: Browser, url: str):
     page.set_default_timeout(60_000)
     console_errors: list[str] = []
     failed: list[str] = []
-    api_calls: list[str] = []
+    requested: list[str] = []
     page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
     page.on("requestfailed", lambda r: failed.append(r.url))
-    page.on("request", lambda r: api_calls.append(r.url) if "/api/" in r.url else None)
-    return page, console_errors, failed, api_calls
+    page.on("request", lambda r: requested.append(r.url))
+    return page, console_errors, failed, requested
 
 
 def test_the_app_boots_and_talks_to_itself_under_the_prefix(browser: Browser, prefixed_url: str) -> None:
-    page, console_errors, failed, api_calls = _watched_page(browser, prefixed_url)
+    page, console_errors, failed, requested = _watched_page(browser, prefixed_url)
     page.goto(f"{prefixed_url}{BASE}/", wait_until="networkidle")
 
     # The shell alone renders an empty <div id="root">. Anything inside it means the bundle was
@@ -60,10 +60,13 @@ def test_the_app_boots_and_talks_to_itself_under_the_prefix(browser: Browser, pr
     # The prefix reached the SPA, not just the server.
     assert page.evaluate("window.__SHORTLIST_BASE_PATH__") == BASE
 
-    # Every API call carries the prefix. A single unprefixed one is the run-log Download bug.
-    assert api_calls, "the SPA made no API calls at all — it never got far enough to be a test"
-    unprefixed = [url for url in api_calls if f"{BASE}/api/" not in url]
-    assert unprefixed == [], f"API calls bypassed the base path: {unprefixed}"
+    # Asserted on the URL, not the response: the app deliberately answers unprefixed paths too,
+    # so an asset or API call that skipped the prefix would still come back 200 and leave both
+    # `failed` and `console_errors` empty. Only the URL shows it.
+    interesting = [u for u in requested if "/api/" in u or "/assets/" in u]
+    assert interesting, "the SPA fetched nothing — it never got far enough to be a test"
+    unprefixed = [u for u in interesting if f"{BASE}/" not in u]
+    assert unprefixed == [], f"requests bypassed the base path: {unprefixed}"
 
     assert failed == [], f"requests failed under the prefix: {failed}"
     assert console_errors == [], f"console errors under the prefix: {console_errors}"

--- a/tests/unit/test_base_path.py
+++ b/tests/unit/test_base_path.py
@@ -1,0 +1,120 @@
+"""APP_BASE_PATH is read at runtime, so the published image can be served from a subpath
+without rebuilding its web bundle. A root deployment must render byte-identical output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from shortlist.server.base_path import (
+    BasePathMiddleware,
+    base_path_from_env,
+    render_shell,
+    resolve_base_path,
+)
+
+SHELL = (
+    "<!doctype html><html><head><title>x</title></head>"
+    '<body><script type="module" src="/assets/index-abc.js"></script>'
+    '<link rel="stylesheet" href="/assets/index-def.css"></body></html>'
+)
+
+
+@pytest.mark.parametrize("raw", [None, "", "   ", "/"])
+def test_root_deployments_resolve_to_empty(raw: str | None) -> None:
+    assert resolve_base_path(raw) == ""
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["/shortlist", "shortlist", "/shortlist/", "shortlist/", "  /shortlist  ", "/shortlist///"],
+)
+def test_accepts_what_people_type_into_a_proxy_config(raw: str) -> None:
+    assert resolve_base_path(raw) == "/shortlist"
+
+
+def test_nested_prefix() -> None:
+    assert resolve_base_path("apps/shortlist/") == "/apps/shortlist"
+
+
+def test_env_is_read_and_normalised() -> None:
+    assert base_path_from_env({"APP_BASE_PATH": "shortlist/"}) == "/shortlist"
+    assert base_path_from_env({}) == ""
+
+
+def test_root_shell_is_returned_untouched() -> None:
+    assert render_shell(SHELL, "") == SHELL
+
+
+def test_subpath_shell_rewrites_assets_and_publishes_the_prefix() -> None:
+    out = render_shell(SHELL, "/shortlist")
+    assert 'src="/shortlist/assets/index-abc.js"' in out
+    assert 'href="/shortlist/assets/index-def.css"' in out
+    assert '"/assets/' not in out
+    assert 'window.__SHORTLIST_BASE_PATH__ = "/shortlist";' in out
+
+
+def test_prefix_is_injected_before_the_bundle_loads() -> None:
+    out = render_shell(SHELL, "/shortlist")
+    assert out.index("__SHORTLIST_BASE_PATH__") < out.index("index-abc.js")
+
+
+def test_prefix_cannot_break_out_of_the_injected_script() -> None:
+    out = render_shell(SHELL, '/a"</script><script>alert(1)</script>')
+    injected = out.split("<script>window.__SHORTLIST_BASE_PATH__ = ")[1].split("</script>")[0]
+    assert "alert(1)" in injected, "the whole value should stay inside the one script element"
+    assert "<\\/script>" in injected
+
+
+class _Recorder:
+    """Minimal ASGI app that records the scope it was called with."""
+
+    def __init__(self) -> None:
+        self.scope: dict | None = None
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.scope = scope
+
+
+def _call(middleware: BasePathMiddleware, path: str, raw_path: bytes | None = None) -> dict:
+    scope: dict = {"type": "http", "path": path, "root_path": ""}
+    if raw_path is not None:
+        scope["raw_path"] = raw_path
+    asyncio.run(middleware(scope, None, None))
+    return middleware.app.scope
+
+
+def test_middleware_publishes_the_prefix_as_root_path() -> None:
+    mw = BasePathMiddleware(_Recorder(), "/shortlist")
+    scope = _call(mw, "/shortlist/api/system/health")
+    assert scope["root_path"] == "/shortlist"
+
+
+def test_path_is_left_whole() -> None:
+    mw = BasePathMiddleware(_Recorder(), "/shortlist")
+    assert _call(mw, "/shortlist/assets/index-abc.js")["path"] == "/shortlist/assets/index-abc.js"
+
+
+def test_an_unprefixed_path_is_untouched() -> None:
+    mw = BasePathMiddleware(_Recorder(), "/shortlist")
+    scope = _call(mw, "/api/system/health")
+    assert scope["root_path"] == ""
+    assert scope["path"] == "/api/system/health"
+
+
+def test_a_lookalike_prefix_is_not_claimed() -> None:
+    mw = BasePathMiddleware(_Recorder(), "/shortlist")
+    assert _call(mw, "/shortlistings/api")["root_path"] == ""
+
+
+def test_the_bare_prefix_is_claimed() -> None:
+    assert _call(BasePathMiddleware(_Recorder(), "/shortlist"), "/shortlist")["root_path"] == "/shortlist"
+
+
+def test_no_base_path_is_a_pass_through() -> None:
+    mw = BasePathMiddleware(_Recorder(), "")
+    scope = _call(mw, "/shortlist/api/x")
+    assert scope["path"] == "/shortlist/api/x"
+    assert scope["root_path"] == ""

--- a/tests/unit/test_base_path.py
+++ b/tests/unit/test_base_path.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from loguru import logger
 
 from shortlist.server.base_path import (
     BasePathMiddleware,
@@ -118,3 +119,55 @@ def test_no_base_path_is_a_pass_through() -> None:
     scope = _call(mw, "/shortlist/api/x")
     assert scope["path"] == "/shortlist/api/x"
     assert scope["root_path"] == ""
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '/a"onload="alert(1)',  # breaks out of the src="…" attribute the prefix is written into
+        '/"><img src=x onerror=alert(1)>',
+        "/shortlist?x=1",  # a query is not part of a path, so this matches no request ever sent
+        "/shortlist#frag",
+        "//evil.com",  # protocol-relative: the SPA would send every API call off-origin
+        "/has space",
+        "/back\\slash",
+    ],
+)
+def test_a_value_that_is_not_a_url_path_is_refused(raw: str) -> None:
+    """Refused at the ONE boundary, because it has two sinks with different escaping.
+
+    `render_shell` JSON-escapes the value for the injected `<script>` but interpolates it RAW into
+    the shell's `src=`/`href=` attributes. The four middle cases are worse than they look: each
+    normalises without complaint and then matches no path the server will ever be asked for, so the
+    app serves from the root while the SPA believes it is prefixed — a blank page, and before this
+    there was nothing in the log to say why.
+    """
+    assert resolve_base_path(raw) == ""
+
+
+@pytest.mark.parametrize("raw", ["/\u0444\u0438\u043b\u044c\u043c\u044b", "/media-1_2.3~x", "/apps/shortlist"])
+def test_an_ordinary_path_is_still_accepted(raw: str) -> None:
+    # Refused by CHARACTER, not permitted by one — an operator whose site is not in ASCII gets to
+    # use a prefix too. The rejected set is only what breaks an HTML attribute or cannot appear in
+    # a request path.
+    assert resolve_base_path(raw) == raw
+
+
+def test_refusing_a_value_says_so() -> None:
+    # loguru does not route through stdlib logging, so `caplog` sees nothing — sink pattern, as
+    # used by the rest of the suite. The whole point of the warning is that the symptom this
+    # prevents (an app serving from the root while the SPA thinks otherwise) is otherwise silent.
+    lines: list[str] = []
+    sink = logger.add(lines.append, level="WARNING", format="{message}")
+    try:
+        assert resolve_base_path("/shortlist?x=1") == ""
+    finally:
+        logger.remove(sink)
+    assert any("APP_BASE_PATH" in line and "/shortlist?x=1" in line for line in lines), lines
+
+
+def test_a_shell_with_no_head_is_a_hard_failure() -> None:
+    # The quiet version of this is a white screen: the assets still resolve, so the app boots, and
+    # then every API call goes to the server root. Better to refuse to start.
+    with pytest.raises(RuntimeError, match="<head>"):
+        render_shell("<html><body>no head here</body></html>", "/shortlist")

--- a/tests/unit/test_base_path.py
+++ b/tests/unit/test_base_path.py
@@ -131,6 +131,10 @@ def test_no_base_path_is_a_pass_through() -> None:
         "//evil.com",  # protocol-relative: the SPA would send every API call off-origin
         "/has space",
         "/back\\slash",
+        "/short%2flist",  # uvicorn decodes before matching, so this never equals what was configured
+        "/a%20b",
+        "/a/../b",  # the browser normalises this out of the asset URL before it asks
+        "/..",
     ],
 )
 def test_a_value_that_is_not_a_url_path_is_refused(raw: str) -> None:

--- a/tests/unit/test_base_path_app.py
+++ b/tests/unit/test_base_path_app.py
@@ -1,0 +1,170 @@
+"""APP_BASE_PATH against the REAL assembled app, not the pieces.
+
+`test_base_path.py` drives the middleware with a stub that records its scope — which proves the
+scope is shaped as intended, and would keep passing if Starlette stopped honouring that shape. The
+load-bearing assumption is Starlette's, not ours: the ASGI spec says `path` carries the whole
+request path INCLUDING `root_path`, and Starlette (>= 0.33, this repo is on 1.3) subtracts
+`root_path` before matching. That is why the middleware leaves `path` alone. Nothing here would
+survive that changing, so it is pinned against a real `create_app()`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from shortlist.server import main as main_module
+
+SECRET = "SUPER-SECRET-FERNET-KEY-DO-NOT-LEAK"
+BUNDLE = "console.log('bundle')"
+SHELL = (
+    "<!doctype html><html><head><title>Shortlist</title>"
+    '<script type="module" crossorigin src="/assets/index-abc.js"></script>'
+    '<link rel="stylesheet" crossorigin href="/assets/index-def.css">'
+    "</head><body><div id=root></div></body></html>"
+)
+
+
+async def _get(app, raw_path: str) -> tuple[int, bytes, dict[str, str]]:
+    """One GET through the whole ASGI stack, with the path left UN-normalized (what a socket sends)."""
+    status: dict[str, int] = {}
+    headers: dict[str, str] = {}
+    chunks: list[bytes] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+            headers.update({k.decode().lower(): v.decode() for k, v in message.get("headers", [])})
+        elif message["type"] == "http.response.body":
+            chunks.append(message.get("body", b""))
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": raw_path,
+            "raw_path": raw_path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "server": ("test", 80),
+            "client": ("1.2.3.4", 9999),
+            "root_path": "",
+        },
+        receive,
+        send,
+    )
+    return status.get("code", 0), b"".join(chunks), headers
+
+
+def get(app, path: str) -> tuple[int, bytes, dict[str, str]]:
+    return asyncio.run(_get(app, path))
+
+
+def _build(tmp_path: Path, monkeypatch, base_path: str | None):
+    web_dist = tmp_path / "web" / "dist"
+    (web_dist / "assets").mkdir(parents=True)
+    (web_dist / "index.html").write_text(SHELL)
+    (web_dist / "assets" / "index-abc.js").write_text(BUNDLE)
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "secret.key").write_text(SECRET)
+    monkeypatch.setattr(main_module, "WEB_DIST", web_dist)
+    if base_path is None:
+        monkeypatch.delenv("APP_BASE_PATH", raising=False)
+    else:
+        monkeypatch.setenv("APP_BASE_PATH", base_path)
+    return main_module.create_app(config_dir=tmp_path / "config")
+
+
+@pytest.fixture
+def prefixed(tmp_path: Path, monkeypatch):
+    return _build(tmp_path, monkeypatch, "/shortlist")
+
+
+@pytest.fixture
+def rooted(tmp_path: Path, monkeypatch):
+    return _build(tmp_path, monkeypatch, None)
+
+
+class TestServedUnderThePrefix:
+    def test_api_routes_match(self, prefixed):
+        status, body, _ = get(prefixed, "/shortlist/api/system/health")
+        assert status == 200, body
+
+    def test_the_assets_mount_matches(self, prefixed):
+        status, body, _ = get(prefixed, "/shortlist/assets/index-abc.js")
+        assert (status, body.decode()) == (200, BUNDLE)
+
+    def test_the_shell_names_its_bundle_under_the_prefix(self, prefixed):
+        _status, body, _ = get(prefixed, "/shortlist/")
+        text = body.decode()
+        assert 'src="/shortlist/assets/index-abc.js"' in text
+        assert 'href="/shortlist/assets/index-def.css"' in text
+        assert '="/assets/' not in text
+
+    def test_the_prefix_is_published_to_the_spa(self, prefixed):
+        _status, body, _ = get(prefixed, "/shortlist/")
+        assert b'window.__SHORTLIST_BASE_PATH__ = "/shortlist";' in body
+
+    def test_the_bare_prefix_redirects_to_the_slash(self, prefixed):
+        # What someone types. Starlette builds the redirect from the FULL path, so the prefix
+        # survives it — a redirect to "/" would bounce the browser out of the app.
+        status, _body, headers = get(prefixed, "/shortlist")
+        assert (status, headers.get("location")) == (307, "http://test/shortlist/")
+
+    def test_a_deep_spa_route_serves_the_shell(self, prefixed):
+        status, body, _ = get(prefixed, "/shortlist/users/42")
+        assert status == 200
+        assert b"__SHORTLIST_BASE_PATH__" in body
+
+    def test_index_html_by_name_is_rewritten_too(self, prefixed):
+        _status, body, _ = get(prefixed, "/shortlist/index.html")
+        assert b'src="/shortlist/assets/index-abc.js"' in body
+
+    def test_the_shell_carries_a_validator(self, prefixed):
+        # The rewritten shell is not the file on disk, so nothing else would give it one, and a
+        # caching proxy in front of a subpath install is the entire point of the feature.
+        _status, _body, headers = get(prefixed, "/shortlist/")
+        assert headers["etag"].startswith('"')
+
+    def test_the_containment_guard_still_holds_under_the_prefix(self, prefixed):
+        # The traversal guard reads the path AFTER root_path is subtracted; a prefix must not
+        # smuggle anything past it.
+        _status, body, _ = get(prefixed, "/shortlist/../config/secret.key")
+        assert SECRET.encode() not in body
+
+
+class TestTheRestOfTheServer:
+    def test_an_unprefixed_path_still_routes(self, prefixed):
+        # The container HEALTHCHECK curls an unprefixed /api/system/health on localhost, so a
+        # subpath install that stopped answering at the root would report itself unhealthy for ever.
+        status, _body, _ = get(prefixed, "/api/system/health")
+        assert status == 200
+
+    def test_a_lookalike_prefix_is_not_claimed(self, prefixed):
+        # "/shortlistings" starts with "/shortlist" as a STRING but is not under it as a PATH.
+        status, body, _ = get(prefixed, "/shortlistings/api/system/health")
+        assert status == 200
+        assert b"__SHORTLIST_BASE_PATH__" in body, "should fall through to the SPA, not the API"
+
+
+class TestARootInstallIsUnchanged:
+    """The feature has to be invisible when it is off — this is what every existing install runs."""
+
+    def test_the_shell_is_served_straight_from_disk(self, rooted):
+        status, body, headers = get(rooted, "/")
+        assert status == 200
+        assert body.decode() == SHELL, "no rewriting when there is no prefix to write in"
+        # `FileResponse`'s own validators, i.e. still the pre-feature response.
+        assert "etag" in headers and "last-modified" in headers
+
+    def test_nothing_is_published_to_the_spa(self, rooted):
+        _status, body, _ = get(rooted, "/")
+        assert b"__SHORTLIST_BASE_PATH__" not in body

--- a/tests/unit/test_base_path_app.py
+++ b/tests/unit/test_base_path_app.py
@@ -141,6 +141,28 @@ class TestServedUnderThePrefix:
         assert SECRET.encode() not in body
 
 
+class TestTheSessionCookie:
+    """Scoped to our prefix, or a subpath install hands it to every neighbour on the hostname.
+
+    Sharing a hostname with another app is the only reason to set APP_BASE_PATH, so the default
+    `path="/"` is wrong exactly when the feature is in use.
+    """
+
+    def _logout_cookie(self, app) -> str:
+        from starlette.testclient import TestClient
+
+        prefix = getattr(app.state, "base_path", "")
+        response = TestClient(app).post(f"{prefix}/api/auth/logout", headers={"x-shortlist-csrf": "1"})
+        assert response.status_code == 200, response.text
+        return response.headers["set-cookie"]
+
+    def test_a_subpath_install_scopes_it(self, prefixed):
+        assert "; Path=/shortlist;" in self._logout_cookie(prefixed)
+
+    def test_a_root_install_is_unchanged(self, rooted):
+        assert "; Path=/;" in self._logout_cookie(rooted)
+
+
 class TestTheRestOfTheServer:
     def test_an_unprefixed_path_still_routes(self, prefixed):
         # The container HEALTHCHECK curls an unprefixed /api/system/health on localhost, so a

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { AppShell } from "@/components/layout/app-shell";
 import { EmptyState, ErrorState } from "@/components/query-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError } from "@/lib/api";
+import { basePath } from "@/lib/base-path";
 import { resolveArea } from "@/lib/auth";
 import { queryKeys, useSession, useSetupState } from "@/lib/queries";
 import { DashboardPage } from "@/pages/dashboard";
@@ -110,7 +111,7 @@ function RequireApp() {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter basename={basePath || "/"}>
         <Routes>
           <Route path="login" element={<LoginPage />} />
           <Route path="setup" element={<SetupPage />} />

--- a/web/src/components/runs/run-log-panel.tsx
+++ b/web/src/components/runs/run-log-panel.tsx
@@ -5,6 +5,7 @@ import { Segmented } from "@/components/segmented";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { apiUrl } from "@/lib/api";
 import {
   countLabel,
   isServerStage,
@@ -162,7 +163,7 @@ export function RunLogPanel({
             Follow
           </label>
           <Button asChild variant="ghost" size="sm">
-            <a href={`/api/runs/${runId}/log?format=text`} download>
+            <a href={apiUrl(`/api/runs/${runId}/log?format=text`)} download>
               <Download className="h-3.5 w-3.5" aria-hidden />
               Download
             </a>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,8 @@ import type {
   WatchedPage,
 } from "./types";
 
+import { basePath } from "./base-path";
+
 /**
  * Error thrown for any failed API call, normalized so the UI can always show
  * a plain-English message. `status` is 0 when the server was unreachable.
@@ -102,7 +104,7 @@ function trimTrailingSlash(value: string): string {
 // reverse proxy). Defaults to same-origin root; override at build time with
 // VITE_API_BASE or at runtime with configureApiBase().
 let apiBase = trimTrailingSlash(
-  (import.meta.env.VITE_API_BASE as string | undefined) ?? "",
+  (import.meta.env.VITE_API_BASE as string | undefined) ?? basePath,
 );
 
 export function configureApiBase(base: string): void {

--- a/web/src/lib/base-path.ts
+++ b/web/src/lib/base-path.ts
@@ -1,0 +1,17 @@
+declare global {
+  interface Window {
+    __SHORTLIST_BASE_PATH__?: string;
+  }
+}
+
+/** Prefix the app is served under, injected into the shell by the server. */
+export function readBasePath(source: Pick<Window, "__SHORTLIST_BASE_PATH__"> | undefined): string {
+  const raw = source?.__SHORTLIST_BASE_PATH__;
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "/") return "";
+  const withLeading = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeading.replace(/\/+$/, "");
+}
+
+export const basePath = readBasePath(typeof window === "undefined" ? undefined : window);

--- a/web/src/test/base-path.test.ts
+++ b/web/src/test/base-path.test.ts
@@ -61,3 +61,35 @@ describe("api base path", () => {
     expect(apiUrl("/api/runs")).toBe("/api/runs");
   });
 });
+
+describe("every API URL goes through apiUrl()", () => {
+  /**
+   * A link that builds its own `/api/...` string works perfectly at the root and 404s the moment
+   * anyone sets APP_BASE_PATH — and nothing else would catch it, because the component renders
+   * fine and the URL only becomes wrong in a deployment the test suite never runs in. The run-log
+   * Download button was exactly this. Scanning the source is the only place the rule is checkable:
+   * it is about the URLs that are NOT constructed, so no rendered output can assert it.
+   */
+  const OFFENDERS = [
+    /(?:href|src|action)=\{?[`"']\/api\//,
+    /\b(?:fetch|EventSource)\(\s*[`"']\/api\//,
+  ];
+
+  // `import.meta.glob` rather than node:fs — the web tsconfig ships no @types/node, so reading the
+  // tree through Vite keeps this typed and keeps `tsc -b` (which CI runs) green.
+  const sources = import.meta.glob("../**/*.{ts,tsx}", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>;
+
+  it("has no hand-built /api URL outside lib/api.ts", () => {
+    const offenders = Object.entries(sources)
+      // `lib/api.ts` is where the prefix is applied; the tests describe URLs rather than use them.
+      .filter(([file]) => file !== "../lib/api.ts" && !file.startsWith("../test/"))
+      .filter(([, source]) => OFFENDERS.some((pattern) => pattern.test(source)))
+      .map(([file]) => file);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/web/src/test/base-path.test.ts
+++ b/web/src/test/base-path.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { readBasePath } from "@/lib/base-path";
+
+describe("readBasePath", () => {
+  it("is empty when the server injected nothing", () => {
+    expect(readBasePath(undefined)).toBe("");
+    expect(readBasePath({})).toBe("");
+    expect(readBasePath({ __SHORTLIST_BASE_PATH__: "" })).toBe("");
+    expect(readBasePath({ __SHORTLIST_BASE_PATH__: "/" })).toBe("");
+  });
+
+  it("normalises whatever the operator put in APP_BASE_PATH", () => {
+    for (const raw of ["/shortlist", "shortlist", "/shortlist/", "  /shortlist  ", "/shortlist//"]) {
+      expect(readBasePath({ __SHORTLIST_BASE_PATH__: raw })).toBe("/shortlist");
+    }
+  });
+
+  it("ignores a non-string global", () => {
+    expect(readBasePath({ __SHORTLIST_BASE_PATH__: 42 as unknown as string })).toBe("");
+  });
+});
+
+describe("api base path", () => {
+  afterEach(() => {
+    delete window.__SHORTLIST_BASE_PATH__;
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  async function freshApiUrl(): Promise<(path: string) => string> {
+    vi.resetModules();
+    const mod = await import("@/lib/api");
+    return mod.apiUrl;
+  }
+
+  it("stays same-origin root when nothing is injected", async () => {
+    vi.stubEnv("VITE_API_BASE", undefined as unknown as string);
+    const apiUrl = await freshApiUrl();
+    expect(apiUrl("/api/runs")).toBe("/api/runs");
+  });
+
+  it("follows the injected prefix", async () => {
+    window.__SHORTLIST_BASE_PATH__ = "/shortlist";
+    vi.stubEnv("VITE_API_BASE", undefined as unknown as string);
+    const apiUrl = await freshApiUrl();
+    expect(apiUrl("/api/runs")).toBe("/shortlist/api/runs");
+  });
+
+  it("lets VITE_API_BASE win, for a split deployment", async () => {
+    window.__SHORTLIST_BASE_PATH__ = "/shortlist";
+    vi.stubEnv("VITE_API_BASE", "https://api.example.com");
+    const apiUrl = await freshApiUrl();
+    expect(apiUrl("/api/runs")).toBe("https://api.example.com/api/runs");
+  });
+
+  it("keeps an explicit empty VITE_API_BASE meaning same-origin root", async () => {
+    window.__SHORTLIST_BASE_PATH__ = "/shortlist";
+    vi.stubEnv("VITE_API_BASE", "");
+    const apiUrl = await freshApiUrl();
+    expect(apiUrl("/api/runs")).toBe("/api/runs");
+  });
+});


### PR DESCRIPTION
`APP_BASE_PATH` is documented as a live env var but nothing reads it, so the app can only be served from a host root. This implements it at runtime — `Dockerfile` and `vite.config.ts` are untouched, so the published image supports it as-is:

    environment:
      - APP_BASE_PATH=/shortlist

An ASGI middleware publishes it as `root_path`; the SPA handler rewrites `/assets/` in the shell and injects the prefix for the router basename and API base. No proxy-side stripping needed, and the container's unprefixed `HEALTHCHECK` still works.

Unset or `/` is a no-op: no middleware, shell bytes unchanged.

14 Python and 7 frontend tests added. Full suites green (3464 / 1291), ruff and eslint clean, verified behind a real Traefik `PathPrefix` router.

CI will show one unrelated failure — `test_a_recent_credit_is_still_withdrawn` hardcodes `NOW = 2026-08-23` against real-clock code and fails on clean `dev` too.

Closes https://github.com/stevezau/shortlist/issues/103
